### PR TITLE
feat: Googleカレンダーイベントの色選択機能を追加

### DIFF
--- a/TrackFit/Services/GoogleCalendarAPI.swift
+++ b/TrackFit/Services/GoogleCalendarAPI.swift
@@ -50,7 +50,8 @@ struct GoogleCalendarAPI {
     /// - Returns: 作成されたイベントの eventId
     static func createWorkoutEvent(
         accessToken: String,
-        workout: DailyWorkout
+        workout: DailyWorkout,
+        colorId: String = "4"  // デフォルトは「みかん」
     ) async throws -> String {
 
         // 1) イベント開始・終了時刻をISO8601文字列に変換
@@ -83,6 +84,7 @@ struct GoogleCalendarAPI {
                 "dateTime": endString,
                 "timeZone": "UTC",
             ],
+            "colorId": colorId,
         ]
 
         // 3) JSONエンコード
@@ -133,7 +135,8 @@ struct GoogleCalendarAPI {
     static func updateWorkoutEvent(
         accessToken: String,
         eventId: String,
-        workout: DailyWorkout
+        workout: DailyWorkout,
+        colorId: String = "4"  // デフォルトは「みかん」
     ) async throws {
         // 1) イベント開始・終了時刻をISO8601文字列に変換
         let startString = DateHelper.iso8601String(from: workout.startDate)
@@ -161,6 +164,7 @@ struct GoogleCalendarAPI {
                 "dateTime": endString,
                 "timeZone": "UTC",
             ],
+            "colorId": colorId,
         ]
 
         let requestData = try JSONSerialization.data(

--- a/TrackFit/ViewModels/WorkoutViewModel.swift
+++ b/TrackFit/ViewModels/WorkoutViewModel.swift
@@ -26,6 +26,9 @@ class WorkoutViewModel: ObservableObject {
     /// Google Sign-In などで取得したアクセストークンを外部からセット
     var accessToken: String = ""
 
+    /// カレンダーイベントの色設定を@AppStorageから取得
+    @AppStorage("calendarEventColor") private var calendarEventColor: CalendarEventColor = .みかん
+
     /// 新規イベント作成
     func createEvent(dailyWorkout: DailyWorkout) async -> Bool {
         do {
@@ -34,7 +37,9 @@ class WorkoutViewModel: ObservableObject {
 
             let accessToken = UserDefaults.standard.string(forKey: "GoogleAccessToken") ?? ""
             let newId = try await GoogleCalendarAPI.createWorkoutEvent(
-                accessToken: accessToken, workout: dailyWorkout)
+                accessToken: accessToken,
+                workout: dailyWorkout,
+                colorId: calendarEventColor.rawValue)
 
             self.eventId = newId
 
@@ -60,7 +65,10 @@ class WorkoutViewModel: ObservableObject {
             errorMessage = nil
 
             try await GoogleCalendarAPI.updateWorkoutEvent(
-                accessToken: accessToken, eventId: eid, workout: dailyWorkout)
+                accessToken: accessToken,
+                eventId: eid,
+                workout: dailyWorkout,
+                colorId: calendarEventColor.rawValue)
 
             isLoading = false
             return true

--- a/TrackFit/Views/SettingView/SettingView.swift
+++ b/TrackFit/Views/SettingView/SettingView.swift
@@ -11,9 +11,58 @@ enum DisplayMode: String {
     case light, dark, system
 }
 
+enum CalendarEventColor: String, CaseIterable, Identifiable {
+    case みかん = "4"
+    case トマト = "11"
+    case フラミンゴ = "5"
+    case バナナ = "9"
+    case セージ = "2"
+    case ピーコック = "6"
+    case ブルーベリー = "1"
+    case ラベンダー = "3"
+    case グレープ = "10"
+    case グラファイト = "8"
+    case デフォルト = "7"
+
+    var id: String { self.rawValue }
+
+    var displayName: String {
+        switch self {
+        case .みかん: return "みかん"
+        case .トマト: return "トマト"
+        case .フラミンゴ: return "フラミンゴ"
+        case .バナナ: return "バナナ"
+        case .セージ: return "セージ"
+        case .ピーコック: return "ピーコック"
+        case .ブルーベリー: return "ブルーベリー"
+        case .ラベンダー: return "ラベンダー"
+        case .グレープ: return "グレープ"
+        case .グラファイト: return "グラファイト"
+        case .デフォルト: return "デフォルト"
+        }
+    }
+
+    var swiftUIColor: Color {
+        switch self {
+        case .みかん: return .orange
+        case .トマト: return .red
+        case .フラミンゴ: return .pink
+        case .バナナ: return .yellow
+        case .セージ: return .green
+        case .ピーコック: return .teal
+        case .ブルーベリー: return .blue
+        case .ラベンダー: return .purple
+        case .グレープ: return .purple
+        case .グラファイト: return .gray
+        case .デフォルト: return .primary
+        }
+    }
+}
+
 struct SettingView: View {
     @AppStorage("displayMode") private var displayMode: DisplayMode = .system
     @AppStorage("isCalendarFeatureEnabled") private var isCalendarFeatureEnabled: Bool = true
+    @AppStorage("calendarEventColor") private var calendarEventColor: CalendarEventColor = .みかん
     @State private var isGoogleCalendarLinked: Bool = false
     @State private var linkedAccountEmail: String? = nil
     @State private var accessToken: String? = nil
@@ -92,6 +141,26 @@ struct SettingView: View {
                                     isShowCalendarIntegration = true
                                 }
                                 .buttonStyle(.borderedProminent)
+                            }
+                        }
+
+                        // カレンダー機能が有効で連携中の場合のみイベント色設定を表示
+                        if isGoogleCalendarLinked {
+                            HStack {
+                                Text("イベントの色")
+                                Spacer()
+                                Picker("", selection: $calendarEventColor) {
+                                    ForEach(CalendarEventColor.allCases) { color in
+                                        HStack {
+                                            Circle()
+                                                .fill(color.swiftUIColor)
+                                                .frame(width: 16, height: 16)
+                                            Text(color.displayName)
+                                        }
+                                        .tag(color)
+                                    }
+                                }
+                                .pickerStyle(.menu)
                             }
                         }
                     }


### PR DESCRIPTION
- CalendarEventColorコンポーネントを追加し11色から選択可能
- 設定画面にイベント色選択のピッカーを追加
- GoogleCalendarAPIでcolorIdパラメータ対応
- WorkoutViewModelでユーザー選択色を反映
- デフォルト色は「みかん」（colorId: 4）に設定

🤖 Generated with [Claude Code](https://claude.ai/code)