### PR TITLE
feat: ホームタブとトレーニング履歴機能の追加

### DIFF
--- a/TrackFit/ViewModels/HomeViewModel.swift
+++ b/TrackFit/ViewModels/HomeViewModel.swift
@@ -1,0 +1,109 @@
+//
+//  HomeViewModel.swift
+//  TrackFit
+//
+//  Created by Ryuga on 2025/08/24.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+class HomeViewModel: ObservableObject {
+    @Published var currentWeekStreak: Int = 0
+    @Published var recentWorkouts: [DailyWorkout] = []
+
+    // 週間アクティビティ (月〜日、7日分)
+    struct DailyActivity: Identifiable {
+        let id = UUID()
+        let label: String  // 曜日ラベル (Mon, Tue...)
+        let count: Int  // アクティビティ回数
+    }
+
+    // ヒートマップ用データ (日付 -> 回数)
+    @Published var activityLog: [Date: Int] = [:]
+
+    func updateStats(workouts: [DailyWorkout]) {
+        self.recentWorkouts = Array(workouts.sorted(by: { $0.startDate > $1.startDate }).prefix(5))
+        self.currentWeekStreak = calculateStreak(workouts: workouts)
+
+        self.activityLog = calculateActivityLog(workouts: workouts)
+    }
+
+    private func calculateStreak(workouts: [DailyWorkout]) -> Int {
+        guard !workouts.isEmpty else { return 0 }
+
+        let sortedWorkouts = workouts.sorted { $0.startDate > $1.startDate }
+        var streak = 0
+        let calendar = Calendar.current
+
+        var workoutWeeks = Set<DateComponent>()  // yearForWeekOfYear, weekOfYear
+
+        for workout in sortedWorkouts {
+            let components = calendar.dateComponents(
+                [.yearForWeekOfYear, .weekOfYear], from: workout.startDate)
+            workoutWeeks.insert(components)
+        }
+
+        // 今週の確認
+        let todayComponents = calendar.dateComponents(
+            [.yearForWeekOfYear, .weekOfYear], from: Date())
+        var currentComponents = todayComponents
+
+        // もし今週の記録がなければ、先週からチェック開始（継続扱いにするか次第だが、今回は厳密に「直近」を見る）
+        // ただし、一般的に「今週まだやってない」だけで0に戻るのは悲しいので、
+        // 「今週やってる」OR「先週やってる（今週はまだこれから）」なら継続とみなすロジックが優しい。
+        // ここではシンプルに「連続した週」をカウントする。
+
+        if !workoutWeeks.contains(currentComponents) {
+            // 今週ないので先週をチェック
+            if let lastWeekDate = calendar.date(byAdding: .weekOfYear, value: -1, to: Date()) {
+                currentComponents = calendar.dateComponents(
+                    [.yearForWeekOfYear, .weekOfYear], from: lastWeekDate)
+                if !workoutWeeks.contains(currentComponents) {
+                    return 0
+                }
+            } else {
+                return 0
+            }
+        }
+
+        // 遡ってカウント
+        while workoutWeeks.contains(currentComponents) {
+            streak += 1
+            if let date = calendar.date(from: currentComponents),
+                let prevWeekDate = calendar.date(byAdding: .weekOfYear, value: -1, to: date)
+            {
+                currentComponents = calendar.dateComponents(
+                    [.yearForWeekOfYear, .weekOfYear], from: prevWeekDate)
+            } else {
+                break
+            }
+        }
+
+        return streak
+    }
+
+    private func calculateActivityLog(workouts: [DailyWorkout]) -> [Date: Int] {
+        let calendar = Calendar.current
+        var log: [Date: Int] = [:]
+
+        for workout in workouts {
+            // 時間情報を切り捨てて日付のみにする
+            let date = calendar.startOfDay(for: workout.startDate)
+            log[date, default: 0] += 1
+        }
+        return log
+    }
+}
+
+// DateComponentをSetで使えるようにHashable準拠（標準で準拠しているはずだが明示的に使うためのエイリアス）
+typealias DateComponent = DateComponents
+
+extension Date {
+    var startOfWeek: Date {
+        let calendar = Calendar.current
+        return calendar.date(
+            from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self))!
+    }
+}

--- a/TrackFit/Views/Components/ActivityHeatmap.swift
+++ b/TrackFit/Views/Components/ActivityHeatmap.swift
@@ -1,0 +1,116 @@
+//
+//  ActivityHeatmap.swift
+//  TrackFit
+//
+//  Created by Ryuga on 2025/08/24.
+//
+
+import SwiftUI
+
+struct ActivityHeatmap: View {
+    let activityLog: [Date: Int]
+
+    // 表示する日数（過去3ヶ月分くらい）
+    let daysToShow = 90
+
+    // カレンダー風: 7行 (Mon-Sun)
+    // 週の数
+    private var weeksCount: Int {
+        (daysToShow / 7) + 2
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("アクティビティログ")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                // GitHub風: 左から右へ時間が進む
+                HStack(spacing: 4) {
+                    ForEach(0..<weeksCount, id: \.self) { weekIndex in
+                        VStack(spacing: 4) {
+                            ForEach(0..<7, id: \.self) { weekdayIndex in
+                                let date = dateFor(weekIndex: weekIndex, weekdayIndex: weekdayIndex)
+                                if let date = date, date <= Date() {
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .fill(colorForActivity(date: date))
+                                        .frame(width: 12, height: 12)
+                                } else {
+                                    // 未来の日付や範囲外
+                                    RoundedRectangle(cornerRadius: 2)
+                                        .fill(Color.gray.opacity(0.1))  // 透明ではなく、枠として薄く表示してもいいが、ここでは薄いグレー
+                                        .frame(width: 12, height: 12)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 4)
+            }
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground))
+        .cornerRadius(16)
+    }
+
+    // MARK: - Helpers
+
+    private var endDate: Date {
+        Date()
+    }
+
+    private var startDate: Date {
+        Calendar.current.date(byAdding: .day, value: -daysToShow, to: endDate)!
+    }
+
+    private func dateFor(weekIndex: Int, weekdayIndex: Int) -> Date? {
+        let calendar = Calendar.current
+        // startDateが含まれる週の始まりを取得 (月曜始まりと仮定)
+        // ここでは単純に startDate から計算するのではなく、グリッドの左端を正確に合わせる必要がある
+        // GitHubのように「一番左の列」は「3ヶ月前の日付が含まれる週」
+
+        guard let startOfFirstWeek = calendar.dateInterval(of: .weekOfYear, for: startDate)?.start
+        else { return nil }
+
+        // オフセット計算
+        // weekIndex週目の、weekdayIndex日目 (0: Mon?)
+        // CalendarのfirstWeekdayを考慮する必要があるが、ここではシンプルに加算
+
+        // 日本のCalendarは日月火... (Sun=1)
+        // weekdayIndex: 0-6 をどうマッピングするか
+        // ここでは VStack 0 が一番上（月曜または日曜）。
+        // UI的には月曜始まりが一般的。 0: Mon, 1: Tue...
+
+        // startOfFirstWeekが日曜の場合、+1dが月曜。
+        // 面倒なので、正確な日付計算を行う。
+
+        let daysToAdd = (weekIndex * 7) + weekdayIndex
+        // しかし、startOfFirstWeekのweekdayを知る必要がある。
+        // startOfFirstWeekは常に日曜(1)だと仮定（日本のカレンダー）
+        // 0番目のセルを日曜にするならそのまま。月曜にするならweekdayIndexとのズレを吸収。
+
+        // ここでは、Visual重視で「とりあえず日付が連続していればOK」とするが、
+        // ちゃんと日付と曜日を合わせる。
+
+        return calendar.date(byAdding: .day, value: daysToAdd, to: startOfFirstWeek)
+    }
+
+    private func colorForActivity(date: Date) -> Color {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        let count = activityLog[startOfDay, default: 0]
+
+        // テーマカラー: TrackFitThemeColor (おそらく赤かオレンジ系?)
+        // なければ青などで代用されるが、Assetにあるはず。
+
+        if count == 0 {
+            return Color.gray.opacity(0.2)
+        } else if count == 1 {
+            return Color.trackFitThemeColor.opacity(0.4)
+        } else if count == 2 {
+            return Color.trackFitThemeColor.opacity(0.7)
+        } else {
+            return Color.trackFitThemeColor
+        }
+    }
+}

--- a/TrackFit/Views/Components/WeeklyActivityChart.swift
+++ b/TrackFit/Views/Components/WeeklyActivityChart.swift
@@ -1,0 +1,38 @@
+//
+//  WeeklyActivityChart.swift
+//  TrackFit
+//
+//  Created by Ryuga on 2025/08/24.
+//
+
+import Charts
+import SwiftUI
+
+struct WeeklyActivityChart: View {
+    let activity: [HomeViewModel.DailyActivity]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("今週のアクティビティ")
+                .font(.headline)
+
+            Chart {
+                ForEach(activity) { item in
+                    BarMark(
+                        x: .value("Day", item.label),
+                        y: .value("Count", item.count)
+                    )
+                    .foregroundStyle(
+                        item.count > 0 ? Color.trackFitThemeColor : Color.gray.opacity(0.3))
+                }
+            }
+            .frame(height: 150)
+            .chartYAxis {
+                AxisMarks(position: .leading, values: .automatic(desiredCount: 3))
+            }
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground))
+        .cornerRadius(16)
+    }
+}

--- a/TrackFit/Views/ContentView.swift
+++ b/TrackFit/Views/ContentView.swift
@@ -12,22 +12,33 @@ import SwiftUI
 struct ContentView: View {
     @Environment(\.colorScheme) var colorScheme
     @StateObject private var viewModel = CalendarViewModel()
-    @State var selection = 0
+    @State private var selection: TabSelection = .home
+    @State private var isSearchPresented = false
     @State private var accessToken: String?
 
-    var body: some View {
-        TabView(selection: $selection) {
-            WorkoutRecordView()
-                .tabItem {
-                    Label("トレーニング記録", systemImage: "timer")
-                }
-                .tag(0)
+    enum TabSelection {
+        case home
+        case workout
+        case history
+        case setting
+    }
 
-            SettingView()
-                .tabItem {
-                    Label("設定", systemImage: "gearshape")
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            TabView(selection: $selection) {
+                Tab("ホーム", systemImage: "house", value: .home) {
+                    HomeView()
                 }
-                .tag(1)
+                Tab("トレーニング記録", systemImage: "timer", value: .workout) {
+                    WorkoutRecordView()
+                }
+                Tab(value: .history, role: .search) {
+                    TrainingHistoryView(isSearchPresented: $isSearchPresented)
+                }
+                Tab("設定", systemImage: "gearshape", value: .setting) {
+                    SettingView()
+                }
+            }
         }
     }
 }

--- a/TrackFit/Views/HomeView/HomeView.swift
+++ b/TrackFit/Views/HomeView/HomeView.swift
@@ -1,0 +1,161 @@
+//
+//  HomeView.swift
+//  TrackFit
+//
+//  Created by Ryuga on 2025/08/24.
+//
+
+import SwiftData
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject private var viewModel = HomeViewModel()
+    @Query(sort: \DailyWorkout.startDate, order: .reverse) private var workouts: [DailyWorkout]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Streak Card
+                    StreakCard(streak: viewModel.currentWeekStreak)
+
+                    // Heatmap
+                    ActivityHeatmap(activityLog: viewModel.activityLog)
+
+                    // Recent Activity
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("最近のアクティビティ")
+                            .font(.headline)
+                            .padding(.horizontal, 4)
+
+                        if viewModel.recentWorkouts.isEmpty {
+                            Text("まだ記録がありません")
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding()
+                        } else {
+                            ForEach(viewModel.recentWorkouts) { workout in
+                                NavigationLink(destination: WorkoutDetailView(workout: workout)) {
+                                    RecentWorkoutRow(workout: workout)
+                                }
+                                .buttonStyle(PlainButtonStyle())
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("ホーム")
+            .onAppear {
+                viewModel.updateStats(workouts: workouts)
+            }
+            .onChange(of: workouts) { _, newWorkouts in
+                viewModel.updateStats(workouts: newWorkouts)
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+
+struct StreakCard: View {
+    let streak: Int
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("継続中")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("\(streak)")
+                        .font(.system(size: 48, weight: .bold, design: .rounded))
+                        .foregroundStyle(Color.trackFitThemeColor)
+
+                    Text("週間")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+
+            Image(systemName: "flame.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 60, height: 60)
+                .foregroundStyle(streak > 0 ? Color.orange : Color.gray.opacity(0.3))
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground))
+        .cornerRadius(16)
+    }
+}
+
+struct StatsCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                    .font(.title3)
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(value)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground))
+        .cornerRadius(16)
+    }
+}
+
+struct RecentWorkoutRow: View {
+    let workout: DailyWorkout
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(workout.startDate.formatted(date: .abbreviated, time: .omitted))
+                    .font(.body)
+                    .fontWeight(.medium)
+
+                Text("\(workout.records.count) 種目")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .padding()
+        .background(Color(uiColor: .secondarySystemBackground))
+        .cornerRadius(12)
+    }
+}
+
+// プレビュー用に簡略化されたWorkoutDetailView（実際のものがなければ）
+// しかし、既存のファイルにあるはずなので、参照できるか確認が必要。
+// おそらく TrainingHistoryView の配下にある詳細画面を使いたいが、
+// 名前がわからないので一旦仮置きするか、既存のものをimportする。
+// ユーザーの作業ファイル情報に `ExerciseDetailView.swift` はあるが `WorkoutDetailView` は見当たらないので
+// コンテキストから探す必要があるが、一旦NavigationLinkの先は仮定する。
+
+// 修正: WorkoutDetailViewが既存のコードベースに存在しない可能性がある。
+// TrainingHistoryViewの中身を確認していないが、履歴詳細画面はあるはず。
+// TrainingHistoryView.swift を確認して、詳細画面のView名を確認する。

--- a/TrackFit/Views/HomeView/WorkoutDetailView.swift
+++ b/TrackFit/Views/HomeView/WorkoutDetailView.swift
@@ -1,0 +1,54 @@
+//
+//  WorkoutDetailView.swift
+//  TrackFit
+//
+//  Created by Ryuga on 2025/08/24.
+//
+
+import SwiftData
+import SwiftUI
+
+struct WorkoutDetailView: View {
+    let workout: DailyWorkout
+
+    var body: some View {
+        List {
+            Section(header: Text("基本情報")) {
+                LabeledContent(
+                    "開始日時", value: workout.startDate.formatted(date: .numeric, time: .shortened))
+                LabeledContent(
+                    "終了日時", value: workout.endDate.formatted(date: .numeric, time: .shortened))
+                if let eventId = workout.eventId, !eventId.isEmpty {
+                    LabeledContent("カレンダー連携", value: "済み")
+                }
+            }
+
+            Section(header: Text("トレーニング内容")) {
+                if workout.records.isEmpty {
+                    Text("記録なし")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(workout.records) { record in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(record.exerciseName)
+                                .font(.headline)
+
+                            HStack {
+                                Text("\(record.weight.formatted()) kg")
+                                    .fontWeight(.bold)
+                                Text("×")
+                                Text("\(record.reps)回")
+                                Text("×")
+                                Text("\(record.sets)セット")
+                            }
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .navigationTitle(workout.startDate.formatted(date: .abbreviated, time: .omitted))
+    }
+}

--- a/TrackFit/Views/TrainingHistoryView/ExerciseDetailView.swift
+++ b/TrackFit/Views/TrainingHistoryView/ExerciseDetailView.swift
@@ -1,0 +1,88 @@
+import Charts
+import SwiftData
+import SwiftUI
+
+struct ExerciseDetailView: View {
+    let exercise: Exercise
+    @Query(sort: \DailyWorkout.startDate, order: .reverse) private var workouts: [DailyWorkout]
+
+    // この種目前の記録のみを抽出（日付降順）
+    private var exerciseHistory: [(date: Date, record: WorkoutRecord)] {
+        var history: [(Date, WorkoutRecord)] = []
+        for workout in workouts {
+            // この日のワークアウトに含まれる、対象種目の記録を探す
+            let matches = workout.records.filter { $0.exerciseName == exercise.name }
+            for record in matches {
+                history.append((workout.startDate, record))
+            }
+        }
+        return history
+    }
+
+    // グラフ用: 日付昇順にならべかえ
+    private var chartData: [(date: Date, maxWeight: Double)] {
+        let history = exerciseHistory.reversed()  // 昇順にする
+        return history.map { ($0.date, $0.record.weight) }
+    }
+
+    var body: some View {
+        List {
+            // MARK: - グラフセクション
+            Section {
+                if chartData.isEmpty {
+                    Text("まだ記録がありません")
+                        .foregroundColor(.secondary)
+                        .padding()
+                } else {
+                    VStack(alignment: .leading) {
+                        Text("重量推移 (Max)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Chart(chartData, id: \.date) { data in
+                            LineMark(
+                                x: .value("日付", data.date),
+                                y: .value("重量", data.maxWeight)
+                            )
+                            .interpolationMethod(.catmullRom)
+                            .symbol(by: .value("日付", data.date))
+                        }
+                        .frame(height: 200)
+                        .padding(.vertical)
+                    }
+                }
+            } header: {
+                Text("成長記録")
+            }
+
+            // MARK: - 履歴リストセクション
+            Section {
+                if exerciseHistory.isEmpty {
+                    Text("記録なし")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(exerciseHistory, id: \.date) { item in
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(DateHelper.formattedDate(item.date))
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            VStack(alignment: .trailing) {
+                                Text("\(item.record.weight, specifier: "%.1f") kg")
+                                    .fontWeight(.bold)
+                                Text("\(item.record.reps) reps × \(item.record.sets) sets")
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("履歴")
+            }
+        }
+        .navigationTitle(exercise.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/TrackFit/Views/TrainingHistoryView/TrainingHistoryView.swift
+++ b/TrackFit/Views/TrainingHistoryView/TrainingHistoryView.swift
@@ -1,0 +1,65 @@
+import SwiftData
+import SwiftUI
+
+struct TrainingHistoryView: View {
+    @Query(sort: \Exercise.name) private var exercises: [Exercise]
+    @State private var searchText = ""
+    @Binding var isSearchPresented: Bool
+
+    init(isSearchPresented: Binding<Bool> = .constant(false)) {
+        self._isSearchPresented = isSearchPresented
+    }
+
+    // カテゴリごとにグループ化された種目リスト
+    // [CategoryName: [Exercise]]
+    private var groupedExercises: [(category: String, exercises: [Exercise])] {
+        let filtered = exercises.filter {
+            searchText.isEmpty || $0.name.localizedCaseInsensitiveContains(searchText)
+        }
+        let grouped = Dictionary(grouping: filtered, by: { $0.category })
+        return grouped.map { (category: $0.key, exercises: $0.value) }
+            .sorted { $0.category < $1.category }  // カテゴリ名でソート
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(groupedExercises, id: \.category) { group in
+                    Section(header: Text(group.category)) {
+                        ForEach(group.exercises) { exercise in
+                            NavigationLink(destination: ExerciseDetailView(exercise: exercise)) {
+                                VStack(alignment: .leading) {
+                                    Text(exercise.name)
+                                        .font(.headline)
+                                    if !exercise.memo.isEmpty {
+                                        Text(exercise.memo)
+                                            .font(.caption)
+                                            .foregroundColor(.gray)
+                                            .lineLimit(1)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .searchable(text: $searchText, isPresented: $isSearchPresented, prompt: "種目を検索")
+            .navigationTitle("履歴")
+            .overlay {
+                if exercises.isEmpty {
+                    ContentUnavailableView(
+                        "種目がありません",
+                        systemImage: "dumbbell",
+                        description: Text("まずはトレーニング記録画面から種目を追加しましょう")
+                    )
+                } else if groupedExercises.isEmpty {
+                    ContentUnavailableView.search(text: searchText)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    TrainingHistoryView()
+}


### PR DESCRIPTION
- ホームタブの実装
  - ダッシュボード形式のホーム画面
  - 週間ストリーク表示
  - アクティビティヒートマップ
  - 最近のワークアウト履歴

- トレーニング履歴タブの実装
  - カテゴリ別の種目一覧表示
  - 検索機能
  - 種目詳細画面（重量推移グラフ + 履歴リスト）

- タブ構成の変更
  - 2タブから4タブ構成へ拡張（ホーム、トレーニング記録、履歴、設定）
  - 型安全なTabSelection enumを導入
  - 履歴タブに検索ロールを設定

- コンポーネントの追加
  - ActivityHeatmap: GitHub風のアクティビティヒートマップ
  - WeeklyActivityChart: 週間アクティビティチャート

- ビューモデルの追加
  - HomeViewModel: ホーム画面のデータ管理
  - ストリーク計算、アクティビティログ管理