### PR TITLE
docs: モデルクラスにドキュメントコメントを追加

### DIFF
--- a/TrackFit/Models/CalendarEvent.swift
+++ b/TrackFit/Models/CalendarEvent.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+/// Googleカレンダーから取得したイベント情報を表すデータモデル
+///
+/// Google Calendar APIのレスポンスを直接デコードするためCodableに準拠。
+/// `CalendarEvent+Workout`拡張でトレーニングデータへの変換機能を提供する。
 struct CalendarEvent: Identifiable, Codable {
     let id: String
     let summary: String?
@@ -19,13 +23,18 @@ struct CalendarEvent: Identifiable, Codable {
     }
 }
 
+/// Googleカレンダーイベントの日時情報
+///
+/// 時間指定イベント（`dateTime`）と終日イベント（`date`）の両方に対応する。
 struct EventDateTime: Codable {
     let dateTime: String?  // 時間指定イベント
     let date: String?  // 終日イベント
     let timeZone: String?
 }
 
-// Workout(トレーニング)用の独自データ
+/// Googleカレンダーイベントから解析したトレーニングデータ
+///
+/// `CalendarEvent.workoutData`で変換された種目・重量・セット・回数の情報を保持する。
 struct WorkoutEventData {
     let exerciseName: String  // 種目
     let weight: String  // 重量(文字列でも可)

--- a/TrackFit/Models/DailyWorkout.swift
+++ b/TrackFit/Models/DailyWorkout.swift
@@ -8,7 +8,10 @@
 import Foundation
 import SwiftData
 
-// MARK: - 1日分のトレーニング記録
+/// 1日分のトレーニング記録を表すSwiftDataモデル
+///
+/// 特定の日に実施した全てのワークアウト（筋トレ・ランニング）をまとめて管理する。
+/// Googleカレンダーとの同期状態も保持する。
 @Model
 class DailyWorkout: Identifiable {
     var id = UUID()

--- a/TrackFit/Models/Exercise.swift
+++ b/TrackFit/Models/Exercise.swift
@@ -8,7 +8,10 @@
 import Foundation
 import SwiftData
 
-// MARK: - トレーニング種目モデル
+/// トレーニング種目のマスターデータを表すSwiftDataモデル
+///
+/// ユーザーが登録した種目（ベンチプレス、スクワットなど）を管理する。
+/// カテゴリ（胸、脚など）でグループ化され、履歴画面での種目別表示に使用される。
 @Model
 class Exercise: Identifiable {
     var id = UUID()

--- a/TrackFit/Models/RunningRecord.swift
+++ b/TrackFit/Models/RunningRecord.swift
@@ -8,6 +8,10 @@
 import Foundation
 import SwiftData
 
+/// ランニング記録を表すSwiftDataモデル
+///
+/// 距離・時間・ペース・ランニング種別（ジョグ・ランなど）を管理する。
+/// Googleカレンダーとの同期状態も保持し、ホーム画面のアクティビティログにも反映される。
 // MARK: - ランニング記録
 @Model
 class RunningRecord: Identifiable {

--- a/TrackFit/Models/WorkoutRecord.swift
+++ b/TrackFit/Models/WorkoutRecord.swift
@@ -8,7 +8,10 @@
 import Foundation
 import SwiftData
 
-// MARK: - 個別のトレーニング記録モデル
+/// 個別のトレーニング記録を表すSwiftDataモデル
+///
+/// 筋トレ（種目名・重量・回数・セット数）とランニング（距離・時間）の両方に対応。
+/// `isRunning`フラグで種別を判別し、対応するプロパティのみ使用する。
 @Model
 class WorkoutRecord: Identifiable {
     var id = UUID()

--- a/TrackFit/Services/AdMobService.swift
+++ b/TrackFit/Services/AdMobService.swift
@@ -1,6 +1,10 @@
 import AppTrackingTransparency
 import GoogleMobileAds
 
+/// Google AdMob広告の初期化と広告ユニットID管理を担当するサービス
+///
+/// ATT（App Tracking Transparency）の許可リクエスト後にAdMobを初期化する。
+/// Debug/Releaseビルドに応じてテスト用・本番用の広告ユニットIDを自動切り替えする。
 class AdMobService: NSObject, ObservableObject {
     static let shared = AdMobService()
     private var isInitialized = false

--- a/TrackFit/Services/GoogleCalendarAPI.swift
+++ b/TrackFit/Services/GoogleCalendarAPI.swift
@@ -8,6 +8,10 @@ import Foundation
 import GoogleSignIn
 import GoogleSignInSwift
 
+/// Google Calendar APIとの通信を担当するサービス層
+///
+/// OAuth認証フロー、イベントのCRUD操作、トークンの自動リフレッシュ機能を提供する。
+/// 認証情報は`KeychainHelper`を通じて安全に管理される。
 struct GoogleCalendarAPI {
     // APIのレスポンス全体
     struct EventsResponse: Codable {

--- a/TrackFit/Utilities/CalendarEvent+Workout.swift
+++ b/TrackFit/Utilities/CalendarEvent+Workout.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Googleカレンダーイベントからトレーニングデータへの変換機能を提供する拡張
 extension CalendarEvent {
     /// description(メモ欄) から WorkoutEventData を解析して返す
     var workoutData: WorkoutEventData? {

--- a/TrackFit/Utilities/Color+Theme.swift
+++ b/TrackFit/Utilities/Color+Theme.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+/// アプリ共通のテーマカラー定義
 extension Color {
     static let trackFitThemeColor = Color(red: 242 / 255, green: 137 / 255, blue: 58 / 255)
 }

--- a/TrackFit/Utilities/Notification+Workout.swift
+++ b/TrackFit/Utilities/Notification+Workout.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// トレーニング記録の同期・連携に使用するカスタム通知名
 extension Notification.Name {
     static let didStartSyncingWorkout = Notification.Name("didStartSyncingWorkout")
     static let didFinishSyncingWorkout = Notification.Name("didFinishSyncingWorkout")

--- a/TrackFit/ViewModels/CalendarViewModel.swift
+++ b/TrackFit/ViewModels/CalendarViewModel.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+/// Googleカレンダーのイベント取得・管理を担当するViewModel
+///
+/// `GoogleCalendarAPI`を通じてカレンダーイベントの取得・作成・更新を行う。
+/// 認証状態の管理とエラーハンドリングも担当する。
 @MainActor
 class CalendarViewModel: ObservableObject {
     @Published var events: [CalendarEvent] = []

--- a/TrackFit/ViewModels/ExerciseViewModel.swift
+++ b/TrackFit/ViewModels/ExerciseViewModel.swift
@@ -8,6 +8,10 @@
 import Foundation
 import SwiftData
 
+/// トレーニング種目のCRUD操作を管理するViewModel
+///
+/// SwiftDataの`ModelContext`を通じて`Exercise`モデルの取得・追加・更新・削除を行う。
+/// カテゴリ別のグループ化機能も提供する。
 @MainActor
 class ExerciseViewModel: ObservableObject {
     private var modelContext: ModelContext

--- a/TrackFit/ViewModels/HomeViewModel.swift
+++ b/TrackFit/ViewModels/HomeViewModel.swift
@@ -8,6 +8,10 @@
 import Foundation
 import SwiftData
 
+/// ホーム画面の状態管理を担当するViewModel
+///
+/// 直近のトレーニング記録、週間ストリーク、アクティビティヒートマップ用データを提供する。
+/// 筋トレ（`DailyWorkout`）とランニング（`RunningRecord`）の両方を統合して集計する。
 @MainActor
 class HomeViewModel: ObservableObject {
     @Published var currentWeekStreak: Int = 0

--- a/TrackFit/ViewModels/RunningViewModel.swift
+++ b/TrackFit/ViewModels/RunningViewModel.swift
@@ -9,6 +9,10 @@ import Foundation
 import SwiftData
 import SwiftUI
 
+/// ランニング記録の入力フォームを管理するViewModel
+///
+/// 距離・時間・ランニング種別の入力状態を保持し、`RunningRecord`の保存・更新・編集を行う。
+/// ペース計算やバリデーション機能も提供する。
 // MARK: - ランニング記録ViewModel
 @MainActor
 class RunningViewModel: ObservableObject {

--- a/TrackFit/ViewModels/WorkoutViewModel.swift
+++ b/TrackFit/ViewModels/WorkoutViewModel.swift
@@ -7,6 +7,10 @@
 
 import SwiftUI
 
+/// トレーニング記録のGoogleカレンダー連携を管理するViewModel
+///
+/// `DailyWorkout`のデータをGoogleカレンダーへ新規作成・更新する機能を提供する。
+/// Keychainからアクセストークンを取得し、`GoogleCalendarAPI`を通じてAPI通信を行う。
 @MainActor
 class WorkoutViewModel: ObservableObject {
     /// 画面で入力するプロパティ


### PR DESCRIPTION
## Summary
- Models（CalendarEvent, RunningRecord, DailyWorkout, WorkoutRecord, Exercise）にSwiftDocコメントを追加
- ViewModels全5ファイル（Home, Workout, Calendar, Exercise, Running）にクラスレベルのドキュメントを追加
- Services（GoogleCalendarAPI, AdMobService）にドキュメントを追加
- Utilities拡張（CalendarEvent+Workout, Color+Theme, Notification+Workout）にドキュメントを追加

## 対象ファイル（15ファイル）
### Models
- `CalendarEvent.swift` - CalendarEvent, EventDateTime, WorkoutEventData
- `RunningRecord.swift` - RunningRecord
- `DailyWorkout.swift` - DailyWorkout
- `WorkoutRecord.swift` - WorkoutRecord
- `Exercise.swift` - Exercise

### ViewModels
- `HomeViewModel.swift` - HomeViewModel
- `WorkoutViewModel.swift` - WorkoutViewModel
- `CalendarViewModel.swift` - CalendarViewModel
- `ExerciseViewModel.swift` - ExerciseViewModel
- `RunningViewModel.swift` - RunningViewModel

### Services
- `GoogleCalendarAPI.swift` - GoogleCalendarAPI
- `AdMobService.swift` - AdMobService

### Utilities
- `CalendarEvent+Workout.swift`
- `Color+Theme.swift`
- `Notification+Workout.swift`

## 備考
- UIの変更なし（ドキュメントコメントのみの追加）
- 既存のドキュメント（KeychainHelper, DateHelper）は十分なSwiftDocが既にあるため変更なし

## Test plan
- [x] swift-formatでフォーマット確認済み
- [x] developブランチにリベース済み
- [x] コードレビューでドキュメント内容の正確性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)