### PR TITLE
refactor: GoogleCalendarAPIのリファクタリング (#116)

### DIFF
--- a/TrackFit/Services/CalendarAPIError.swift
+++ b/TrackFit/Services/CalendarAPIError.swift
@@ -1,0 +1,32 @@
+//
+//  CalendarAPIError.swift
+//  TrackFit
+//
+//  Refactored from GoogleCalendarAPI.swift
+//
+
+import Foundation
+
+/// Google Calendar API通信で発生するエラーを統一的に扱うエラー型
+enum CalendarAPIError: LocalizedError {
+    case invalidURL
+    case httpError(statusCode: Int, body: String)
+    case tokenNotFound
+    case tokenExpired
+    case refreshFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "無効なURLです"
+        case .httpError(let statusCode, let body):
+            return "APIエラー (\(statusCode))\n\(body)"
+        case .tokenNotFound:
+            return "アクセストークンが見つかりません"
+        case .tokenExpired:
+            return "アクセストークンの期限が切れています"
+        case .refreshFailed(let underlying):
+            return "トークン更新に失敗しました: \(underlying.localizedDescription)"
+        }
+    }
+}

--- a/TrackFit/Services/GoogleAuthService.swift
+++ b/TrackFit/Services/GoogleAuthService.swift
@@ -1,0 +1,223 @@
+//
+//  GoogleAuthService.swift
+//  TrackFit
+//
+//  Refactored from GoogleCalendarAPI.swift
+//
+
+import Foundation
+import GoogleSignIn
+
+/// Google OAuth認証とトークン管理を担当するサービス
+///
+/// サインイン・サインアウト、トークンのリフレッシュ、連携状態の確認を行う。
+/// 認証情報は`KeychainHelper`を通じてKeychainに安全に保存される。
+struct GoogleAuthService {
+
+    // MARK: - 連携・解除
+
+    /// Googleカレンダーとの連携処理（OAuth認証フローを実行）
+    static func linkGoogleCalendar() async throws -> Bool {
+        guard let clientID = Bundle.main.object(forInfoDictionaryKey: "CLIENT_ID") as? String else {
+            #if DEBUG
+                print("CLIENT_ID が見つかりません")
+            #endif
+            return false
+        }
+
+        GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
+
+        let rootViewController = await MainActor.run { () -> UIViewController? in
+            guard
+                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                let window = windowScene.windows.first,
+                let rootViewController = window.rootViewController
+            else {
+                return nil
+            }
+            return rootViewController
+        }
+
+        guard let rootViewController = rootViewController else {
+            return false
+        }
+
+        let signInResult = try await GIDSignIn.sharedInstance.signIn(
+            withPresenting: rootViewController,
+            hint: nil,
+            additionalScopes: [
+                "https://www.googleapis.com/auth/calendar.readonly",
+                "https://www.googleapis.com/auth/calendar.events",
+            ]
+        )
+
+        let user = signInResult.user
+        let accessToken = user.accessToken.tokenString
+        let refreshToken = user.refreshToken.tokenString
+        let email = user.profile?.email ?? "user@gmail.com"
+        let expiryDate = user.accessToken.expirationDate
+
+        let keychain = KeychainHelper.shared
+        _ = keychain.save(accessToken, forKey: KeychainHelper.GoogleTokenKeys.accessToken)
+        _ = keychain.save(email, forKey: KeychainHelper.GoogleTokenKeys.email)
+        _ = keychain.save(refreshToken, forKey: KeychainHelper.GoogleTokenKeys.refreshToken)
+
+        if let expiryDate = expiryDate {
+            let expiryTimestamp = String(expiryDate.timeIntervalSince1970)
+            _ = keychain.save(
+                expiryTimestamp, forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate)
+        }
+
+        #if DEBUG
+            print("ログイン成功!")
+            print("accessToken: 取得済み")
+            print("refreshToken: 保存済み")
+        #endif
+        UserDefaults.standard.set(true, forKey: "isCalendarLinked")
+        return true
+    }
+
+    /// Googleカレンダーとの連携解除処理
+    static func unlinkGoogleCalendar() {
+        GIDSignIn.sharedInstance.signOut()
+
+        let keychain = KeychainHelper.shared
+        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.accessToken)
+        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.refreshToken)
+        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.email)
+        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate)
+
+        #if DEBUG
+            print("Google認証情報をすべて削除しました")
+        #endif
+    }
+
+    // MARK: - トークン管理
+
+    /// リフレッシュトークンを使用してアクセストークンを更新
+    static func refreshAccessToken() async throws -> String {
+        do {
+            let result = try await GIDSignIn.sharedInstance.restorePreviousSignIn()
+            let newAccessToken = result.accessToken.tokenString
+            let newExpiryDate = result.accessToken.expirationDate
+
+            let keychain = KeychainHelper.shared
+            _ = keychain.save(newAccessToken, forKey: KeychainHelper.GoogleTokenKeys.accessToken)
+
+            if let expiryDate = newExpiryDate {
+                let expiryTimestamp = String(expiryDate.timeIntervalSince1970)
+                _ = keychain.save(
+                    expiryTimestamp, forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate)
+            }
+
+            #if DEBUG
+                print("アクセストークンを更新しました")
+            #endif
+            return newAccessToken
+        } catch {
+            #if DEBUG
+                print("トークン更新エラー: \(error.localizedDescription)")
+            #endif
+            throw CalendarAPIError.refreshFailed(underlying: error)
+        }
+    }
+
+    /// アクセストークンの有効性チェック（期限チェック含む）
+    static func validateAccessToken(accessToken: String? = nil) async -> Bool {
+        let token =
+            accessToken
+            ?? KeychainHelper.shared.loadString(forKey: KeychainHelper.GoogleTokenKeys.accessToken)
+
+        guard let token = token else {
+            #if DEBUG
+                print("アクセストークンが見つかりません")
+            #endif
+            return false
+        }
+
+        if isTokenExpired() {
+            #if DEBUG
+                print("アクセストークンの期限が切れています")
+            #endif
+            return false
+        }
+
+        guard let url = URL(string: "https://www.googleapis.com/calendar/v3/calendars/primary")
+        else {
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse {
+                return (200..<300).contains(httpResponse.statusCode)
+            }
+        } catch {
+            #if DEBUG
+                print("トークン検証エラー: \(error.localizedDescription)")
+            #endif
+        }
+        return false
+    }
+
+    /// トークンの期限切れチェック
+    static func isTokenExpired() -> Bool {
+        guard
+            let expiryTimestampString = KeychainHelper.shared.loadString(
+                forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate),
+            let expiryTimestamp = Double(expiryTimestampString)
+        else {
+            return true
+        }
+
+        let expiryDate = Date(timeIntervalSince1970: expiryTimestamp)
+        let bufferTime: TimeInterval = 5 * 60
+        return Date().addingTimeInterval(bufferTime) >= expiryDate
+    }
+
+    // MARK: - 連携状態チェック
+
+    /// 連携状態の自動チェックと更新
+    static func checkAndUpdateLinkingStatus() async {
+        guard
+            let accessToken = KeychainHelper.shared.loadString(
+                forKey: KeychainHelper.GoogleTokenKeys.accessToken),
+            !accessToken.isEmpty
+        else {
+            await MainActor.run {
+                UserDefaults.standard.set(false, forKey: "isCalendarLinked")
+                UserDefaults.standard.set(true, forKey: "showIntegrationBanner")
+            }
+            return
+        }
+
+        let isValid = await validateAccessToken(accessToken: accessToken)
+        await MainActor.run {
+            if !isValid {
+                Task {
+                    do {
+                        _ = try await refreshAccessToken()
+                        UserDefaults.standard.set(true, forKey: "isCalendarLinked")
+                        #if DEBUG
+                            print("アクセストークンを更新しました")
+                        #endif
+                    } catch {
+                        unlinkGoogleCalendar()
+                        UserDefaults.standard.set(false, forKey: "isCalendarLinked")
+                        UserDefaults.standard.set(true, forKey: "showIntegrationBanner")
+                        #if DEBUG
+                            print(
+                                "トークン更新に失敗したため連携を解除しました: \(error.localizedDescription)")
+                        #endif
+                    }
+                }
+            } else {
+                UserDefaults.standard.set(true, forKey: "isCalendarLinked")
+            }
+        }
+    }
+}

--- a/TrackFit/Services/GoogleCalendarAPI.swift
+++ b/TrackFit/Services/GoogleCalendarAPI.swift
@@ -4,447 +4,63 @@
 //
 //  Created by Ryuga on 2024/12/28.
 //
-import Foundation
-import GoogleSignIn
-import GoogleSignInSwift
 
+import Foundation
+
+/// Google Calendar APIのCRUD操作を担当するサービス
+///
+/// イベントの取得・作成・更新を行う。
+/// 認証トークンの管理は`GoogleAuthService`、エラー型は`CalendarAPIError`に分離。
 struct GoogleCalendarAPI {
-    // APIのレスポンス全体
+
+    // MARK: - Response Types
+
     struct EventsResponse: Codable {
         let items: [CalendarEvent]
     }
 
+    private struct CreateEventResponse: Decodable {
+        let id: String
+    }
+
+    // MARK: - Public API
+
+    /// カレンダーイベントを取得
     static func fetchEvents(accessToken: String) async throws -> [CalendarEvent] {
         return try await makeAPICallWithAutoRefresh { token in
-            return try await _fetchEvents(accessToken: token)
+            return try await performFetchEvents(accessToken: token)
         }
     }
 
-    private static func _fetchEvents(accessToken: String) async throws -> [CalendarEvent] {
-        // プライマリカレンダーのイベントを取得する
-        guard
-            let url = URL(
-                string:
-                    "https://www.googleapis.com/calendar/v3/calendars/primary/events?maxResults=20&orderBy=startTime&singleEvents=true&orderBy=startTime&timeMin=2024-01-01T00%3A00%3A00Z&timeMax=2024-02-01T00%3A00%3A00Z"
-            )
-        else {
-            throw URLError(.badURL)
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-
-        // async/await で通信
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        // ステータスコードチェック (例)
-        if let httpResponse = response as? HTTPURLResponse,
-            !(200..<300).contains(httpResponse.statusCode)
-        {
-            #if DEBUG
-                print("Status Code:", httpResponse.statusCode)
-            #endif
-            throw URLError(.badServerResponse)
-        }
-        #if DEBUG
-            print("Response body:", String(data: data, encoding: .utf8) ?? "N/A")
-        #endif
-
-        // JSONデコード
-        let decoded = try JSONDecoder().decode(EventsResponse.self, from: data)
-        return decoded.items
-    }
-
-    /// Google Calendar へ新規イベントを追加 (POST)
-    /// - Returns: 作成されたイベントの eventId
+    /// 新規イベントを作成
+    /// - Returns: 作成されたイベントのID
     static func createWorkoutEvent(
         accessToken: String,
         workout: DailyWorkout,
-        colorId: String = "4"  // デフォルトは「みかん」
+        colorId: String = "4"
     ) async throws -> String {
         return try await makeAPICallWithAutoRefresh { token in
-            return try await _createWorkoutEvent(
+            return try await performCreateWorkoutEvent(
                 accessToken: token, workout: workout, colorId: colorId)
         }
     }
 
-    private static func _createWorkoutEvent(
-        accessToken: String,
-        workout: DailyWorkout,
-        colorId: String = "4"
-    ) async throws -> String {
-
-        // 1) イベント開始・終了時刻をISO8601文字列に変換
-        let startString = DateHelper.iso8601String(from: workout.startDate)
-        let endString = DateHelper.iso8601String(from: workout.endDate)
-
-        // 2) イベントの要素をJSONに組み立て
-        // 各レコードの詳細を文字列に変換し、改行で結合
-        let descriptionText = workout.records.map { record in
-            """
-            種目: \(record.exerciseName)
-            重量: \(record.weight) kg
-            セット数: \(record.sets)
-            回数: \(record.reps)
-            """
-        }.joined(separator: "\n\n")
-
-        // イベント作成用のリクエストボディにまとめる
-        //   - summary: イベントのタイトル
-        //   - description: メモ欄 (種目・重量・セット数・回数などをここに記載)
-        //   - start/end: ISO8601形式の日付
-        let newEventRequestBody: [String: Any] = [
-            "summary": "トレーニング",
-            "description": descriptionText,
-            "start": [
-                "dateTime": startString,
-                "timeZone": "UTC",
-            ],
-            "end": [
-                "dateTime": endString,
-                "timeZone": "UTC",
-            ],
-            "colorId": colorId,
-        ]
-
-        // 3) JSONエンコード
-        let requestData = try JSONSerialization.data(
-            withJSONObject: newEventRequestBody, options: [])
-
-        // 4) URLRequest 作成
-        guard
-            let url = URL(string: "https://www.googleapis.com/calendar/v3/calendars/primary/events")
-        else {
-            throw URLError(.badURL)
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
-        request.httpBody = requestData
-
-        // 5) URLSession でリクエスト (async/await)
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        // 6) ステータスコードチェック
-        if let httpResponse = response as? HTTPURLResponse,
-            !(200..<300).contains(httpResponse.statusCode)
-        {
-            // 失敗時のレスポンスを表示（デバッグ用）
-            let bodyString = String(data: data, encoding: .utf8) ?? "N/A"
-            throw NSError(
-                domain: "GoogleCalendarAPI", code: httpResponse.statusCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "イベント作成失敗 (\(httpResponse.statusCode))\n\(bodyString)"
-                ])
-        }
-
-        // 7) イベントIDをレスポンスから取得
-        struct CreateEventResponse: Decodable {
-            let id: String
-        }
-        let decoded = try JSONDecoder().decode(CreateEventResponse.self, from: data)
-
-        return decoded.id
-    }
-
-    /// 既存イベントを更新 (PATCH)
-    /// - Parameter eventId: 更新対象のイベントID
+    /// 既存イベントを更新
     static func updateWorkoutEvent(
         accessToken: String,
         eventId: String,
         workout: DailyWorkout,
-        colorId: String = "4"  // デフォルトは「みかん」
+        colorId: String = "4"
     ) async throws {
         return try await makeAPICallWithAutoRefresh { token in
-            return try await _updateWorkoutEvent(
+            return try await performUpdateWorkoutEvent(
                 accessToken: token, eventId: eventId, workout: workout, colorId: colorId)
         }
     }
 
-    private static func _updateWorkoutEvent(
-        accessToken: String,
-        eventId: String,
-        workout: DailyWorkout,
-        colorId: String = "4"
-    ) async throws {
-        // 1) イベント開始・終了時刻をISO8601文字列に変換
-        let startString = DateHelper.iso8601String(from: workout.startDate)
-        let endString = DateHelper.iso8601String(from: workout.endDate)
-        // 2) イベントの要素をJSONに組み立て
-        // 各レコードの詳細を文字列に変換し、改行で結合
-        let descriptionText = workout.records.map { record in
-            """
-            種目: \(record.exerciseName)
-            重量: \(record.weight) kg
-            セット数: \(record.sets)
-            回数: \(record.reps)
-            """
-        }.joined(separator: "\n\n")
+    // MARK: - Auto-Refresh Helper
 
-        // 2) 更新内容をJSONに組み立て
-        let updateEventRequestBody: [String: Any] = [
-            "summary": "トレーニング",
-            "description": descriptionText,
-            "start": [
-                "dateTime": startString,
-                "timeZone": "UTC",
-            ],
-            "end": [
-                "dateTime": endString,
-                "timeZone": "UTC",
-            ],
-            "colorId": colorId,
-        ]
-
-        let requestData = try JSONSerialization.data(
-            withJSONObject: updateEventRequestBody, options: [])
-
-        // 3) PATCHエンドポイント
-        //    - PUT でもOKですが、PATCHのほうが一部更新に向いています (Google Calendar API ドキュメントより)
-        guard
-            let url = URL(
-                string: "https://www.googleapis.com/calendar/v3/calendars/primary/events/\(eventId)"
-            )
-        else {
-            throw URLError(.badURL)
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
-        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
-        request.httpBody = requestData
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-            !(200..<300).contains(httpResponse.statusCode)
-        {
-            let bodyString = String(data: data, encoding: .utf8) ?? "N/A"
-            throw NSError(
-                domain: "GoogleCalendarAPI", code: httpResponse.statusCode,
-                userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "イベント更新失敗 (\(httpResponse.statusCode))\n\(bodyString)"
-                ])
-        }
-    }
-
-    // Googleカレンダーとの連携処理（OAuth認証フローを実行）
-    static func linkGoogleCalendar() async throws -> Bool {
-        do {
-            guard
-                let clientID = Bundle.main.object(forInfoDictionaryKey: "CLIENT_ID") as? String
-            else {
-                #if DEBUG
-                    print("CLIENT_ID が見つかりません")
-                #endif
-                return false
-            }
-
-            GIDSignIn.sharedInstance.configuration = GIDConfiguration(clientID: clientID)
-
-            let rootViewController = await MainActor.run { () -> UIViewController? in
-                guard
-                    let windowScene = UIApplication.shared.connectedScenes.first
-                        as? UIWindowScene,
-                    let window = windowScene.windows.first,
-                    let rootViewController = window.rootViewController
-                else {
-                    return nil
-                }
-                return rootViewController
-            }
-
-            guard let rootViewController = rootViewController else {
-                return false
-            }
-
-            let signInResult = try await GIDSignIn.sharedInstance.signIn(
-                withPresenting: rootViewController,
-                hint: nil,
-                additionalScopes: [
-                    "https://www.googleapis.com/auth/calendar.readonly",
-                    "https://www.googleapis.com/auth/calendar.events",
-                ]
-            )
-
-            let user = signInResult.user
-            let idToken = user.idToken?.tokenString
-            let accessToken = user.accessToken.tokenString
-            let refreshToken = user.refreshToken.tokenString
-            let email = user.profile?.email ?? "user@gmail.com"
-            let expiryDate = user.accessToken.expirationDate
-
-            // Keychainに安全に保存
-            let keychain = KeychainHelper.shared
-            _ = keychain.save(accessToken, forKey: KeychainHelper.GoogleTokenKeys.accessToken)
-            _ = keychain.save(email, forKey: KeychainHelper.GoogleTokenKeys.email)
-
-            _ = keychain.save(refreshToken, forKey: KeychainHelper.GoogleTokenKeys.refreshToken)
-
-            if let expiryDate = expiryDate {
-                let expiryTimestamp = String(expiryDate.timeIntervalSince1970)
-                _ = keychain.save(
-                    expiryTimestamp, forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate)
-            }
-
-            #if DEBUG
-                print("ログイン成功!")
-                print("idToken: \(idToken != nil ? "取得済み" : "なし")")
-                print("accessToken: 取得済み")
-                print("refreshToken: 保存済み")
-            #endif
-            UserDefaults.standard.set(true, forKey: "isCalendarLinked")
-            return true
-
-        } catch {
-            #if DEBUG
-                print("ログインエラー: \(error.localizedDescription)")
-            #endif
-            return false
-        }
-    }
-
-    // アクセストークンの有効性チェック（期限チェック含む）
-    static func validateAccessToken(accessToken: String? = nil) async -> Bool {
-        let token =
-            accessToken
-            ?? KeychainHelper.shared.loadString(forKey: KeychainHelper.GoogleTokenKeys.accessToken)
-
-        guard let token = token else {
-            #if DEBUG
-                print("アクセストークンが見つかりません")
-            #endif
-            return false
-        }
-
-        // 期限チェック
-        if isTokenExpired() {
-            #if DEBUG
-                print("アクセストークンの期限が切れています")
-            #endif
-            return false
-        }
-
-        guard
-            let url = URL(
-                string: "https://www.googleapis.com/calendar/v3/calendars/primary"
-            )
-        else {
-            return false
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-
-        do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse {
-                return (200..<300).contains(httpResponse.statusCode)
-            }
-        } catch {
-            #if DEBUG
-                print("トークン検証エラー: \(error.localizedDescription)")
-            #endif
-        }
-        return false
-    }
-
-    // トークンの期限切れチェック
-    private static func isTokenExpired() -> Bool {
-        guard
-            let expiryTimestampString = KeychainHelper.shared.loadString(
-                forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate),
-            let expiryTimestamp = Double(expiryTimestampString)
-        else {
-            // 期限情報がない場合は期限切れとして扱う
-            return true
-        }
-
-        let expiryDate = Date(timeIntervalSince1970: expiryTimestamp)
-        let bufferTime: TimeInterval = 5 * 60  // 5分のバッファ
-        return Date().addingTimeInterval(bufferTime) >= expiryDate
-    }
-
-    // 連携状態の自動チェックと更新
-    static func checkAndUpdateLinkingStatus() async {
-        guard
-            let accessToken = KeychainHelper.shared.loadString(
-                forKey: KeychainHelper.GoogleTokenKeys.accessToken),
-            !accessToken.isEmpty
-        else {
-            // トークンが存在しない場合は連携解除状態に設定
-            await MainActor.run {
-                UserDefaults.standard.set(false, forKey: "isCalendarLinked")
-                UserDefaults.standard.set(true, forKey: "showIntegrationBanner")
-            }
-            return
-        }
-
-        let isValid = await validateAccessToken(accessToken: accessToken)
-        await MainActor.run {
-            if !isValid {
-                // トークンが無効な場合はリフレッシュを試行
-                Task {
-                    do {
-                        _ = try await refreshAccessToken()
-                        UserDefaults.standard.set(true, forKey: "isCalendarLinked")
-                        #if DEBUG
-                            print("アクセストークンを更新しました")
-                        #endif
-                    } catch {
-                        // リフレッシュに失敗した場合は連携解除
-                        unlinkGoogleCalendar()
-                        UserDefaults.standard.set(false, forKey: "isCalendarLinked")
-                        UserDefaults.standard.set(true, forKey: "showIntegrationBanner")
-                        #if DEBUG
-                            print("トークン更新に失敗したため連携を解除しました: \(error.localizedDescription)")
-                        #endif
-                    }
-                }
-            } else {
-                // トークンが有効な場合は連携状態を確認
-                UserDefaults.standard.set(true, forKey: "isCalendarLinked")
-            }
-        }
-    }
-
-    // リフレッシュトークンを使用してアクセストークンを更新
-    static func refreshAccessToken() async throws -> String {
-        do {
-            // GoogleSignInのrestorePreviousSignInを使用してトークンを更新
-            let result = try await GIDSignIn.sharedInstance.restorePreviousSignIn()
-            let newAccessToken = result.accessToken.tokenString
-            let newExpiryDate = result.accessToken.expirationDate
-
-            // 新しいトークンをKeychainに保存
-            let keychain = KeychainHelper.shared
-            _ = keychain.save(newAccessToken, forKey: KeychainHelper.GoogleTokenKeys.accessToken)
-
-            if let expiryDate = newExpiryDate {
-                let expiryTimestamp = String(expiryDate.timeIntervalSince1970)
-                _ = keychain.save(
-                    expiryTimestamp, forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate)
-            }
-
-            #if DEBUG
-                print("アクセストークンを更新しました")
-            #endif
-            return newAccessToken
-        } catch {
-            #if DEBUG
-                print("トークン更新エラー: \(error.localizedDescription)")
-            #endif
-            throw error
-        }
-    }
-
-    // 自動リトライ機能付きのAPI呼び出しヘルパー
+    /// 自動リトライ機能付きのAPI呼び出しヘルパー
     static func makeAPICallWithAutoRefresh<T>(_ apiCall: @escaping (String) async throws -> T)
         async throws -> T
     {
@@ -455,32 +71,141 @@ struct GoogleCalendarAPI {
         do {
             return try await apiCall(accessToken)
         } catch {
-            // HTTP 401エラーまたはトークン期限切れの場合はリトライ
-            if let nsError = error as NSError?, nsError.code == 401 || isTokenExpired() {
+            if let nsError = error as NSError?,
+                nsError.code == 401 || GoogleAuthService.isTokenExpired()
+            {
                 #if DEBUG
                     print("認証エラーを検出、トークンを更新してリトライします")
                 #endif
-                let newToken = try await refreshAccessToken()
+                let newToken = try await GoogleAuthService.refreshAccessToken()
                 return try await apiCall(newToken)
             }
             throw error
         }
     }
 
-    // Googleカレンダーとの連携解除処理
-    static func unlinkGoogleCalendar() {
-        // Googleサインアウト処理
-        GIDSignIn.sharedInstance.signOut()
+    // MARK: - Private Implementation
 
-        // Keychainから全ての認証情報を削除
-        let keychain = KeychainHelper.shared
-        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.accessToken)
-        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.refreshToken)
-        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.email)
-        _ = keychain.delete(forKey: KeychainHelper.GoogleTokenKeys.tokenExpiryDate)
+    private static func performFetchEvents(accessToken: String) async throws -> [CalendarEvent] {
+        guard
+            let url = URL(
+                string:
+                    "https://www.googleapis.com/calendar/v3/calendars/primary/events?maxResults=20&orderBy=startTime&singleEvents=true&orderBy=startTime&timeMin=2024-01-01T00%3A00%3A00Z&timeMax=2024-02-01T00%3A00%3A00Z"
+            )
+        else {
+            throw CalendarAPIError.invalidURL
+        }
+
+        let (data, response) = try await performRequest(
+            url: url, method: "GET", accessToken: accessToken)
+        try validateResponse(response, data: data)
 
         #if DEBUG
-            print("Google認証情報をすべて削除しました")
+            print("Response body:", String(data: data, encoding: .utf8) ?? "N/A")
         #endif
+
+        let decoded = try JSONDecoder().decode(EventsResponse.self, from: data)
+        return decoded.items
+    }
+
+    private static func performCreateWorkoutEvent(
+        accessToken: String,
+        workout: DailyWorkout,
+        colorId: String
+    ) async throws -> String {
+        guard
+            let url = URL(string: "https://www.googleapis.com/calendar/v3/calendars/primary/events")
+        else {
+            throw CalendarAPIError.invalidURL
+        }
+
+        let requestBody = buildWorkoutEventBody(workout: workout, colorId: colorId)
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody, options: [])
+
+        let (data, response) = try await performRequest(
+            url: url, method: "POST", accessToken: accessToken, body: requestData)
+        try validateResponse(response, data: data)
+
+        let decoded = try JSONDecoder().decode(CreateEventResponse.self, from: data)
+        return decoded.id
+    }
+
+    private static func performUpdateWorkoutEvent(
+        accessToken: String,
+        eventId: String,
+        workout: DailyWorkout,
+        colorId: String
+    ) async throws {
+        guard
+            let url = URL(
+                string: "https://www.googleapis.com/calendar/v3/calendars/primary/events/\(eventId)"
+            )
+        else {
+            throw CalendarAPIError.invalidURL
+        }
+
+        let requestBody = buildWorkoutEventBody(workout: workout, colorId: colorId)
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody, options: [])
+
+        let (data, response) = try await performRequest(
+            url: url, method: "PATCH", accessToken: accessToken, body: requestData)
+        try validateResponse(response, data: data)
+    }
+
+    // MARK: - Shared Helpers
+
+    /// 共通のHTTPリクエスト実行
+    private static func performRequest(
+        url: URL, method: String, accessToken: String, body: Data? = nil
+    ) async throws -> (Data, URLResponse) {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        if body != nil {
+            request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
+            request.httpBody = body
+        }
+        return try await URLSession.shared.data(for: request)
+    }
+
+    /// 共通のレスポンスバリデーション
+    private static func validateResponse(_ response: URLResponse, data: Data) throws {
+        if let httpResponse = response as? HTTPURLResponse,
+            !(200..<300).contains(httpResponse.statusCode)
+        {
+            let bodyString = String(data: data, encoding: .utf8) ?? "N/A"
+            throw CalendarAPIError.httpError(statusCode: httpResponse.statusCode, body: bodyString)
+        }
+    }
+
+    /// ワークアウトイベントのリクエストボディを生成
+    private static func buildWorkoutEventBody(workout: DailyWorkout, colorId: String)
+        -> [String: Any]
+    {
+        let startString = DateHelper.iso8601String(from: workout.startDate)
+        let endString = DateHelper.iso8601String(from: workout.endDate)
+
+        let descriptionText = workout.records.map { record in
+            """
+            種目: \(record.exerciseName)
+            重量: \(record.weight) kg
+            セット数: \(record.sets)
+            回数: \(record.reps)
+            """
+        }.joined(separator: "\n\n")
+
+        return [
+            "summary": "トレーニング",
+            "description": descriptionText,
+            "start": [
+                "dateTime": startString,
+                "timeZone": "UTC",
+            ],
+            "end": [
+                "dateTime": endString,
+                "timeZone": "UTC",
+            ],
+            "colorId": colorId,
+        ]
     }
 }

--- a/TrackFit/Views/GoogleCalendarIntegrationView.swift
+++ b/TrackFit/Views/GoogleCalendarIntegrationView.swift
@@ -88,7 +88,7 @@ struct GoogleCalendarIntegrationView: View {
 
                         Button {
                             Task {
-                                let success = try await GoogleCalendarAPI.linkGoogleCalendar()
+                                let success = try await GoogleAuthService.linkGoogleCalendar()
                                 await MainActor.run {
                                     if success {
                                         onFinish(true)

--- a/TrackFit/Views/SettingView/SettingView.swift
+++ b/TrackFit/Views/SettingView/SettingView.swift
@@ -91,7 +91,7 @@ struct SettingView: View {
                                 if !newValue {
                                     // 機能をオフにした場合、連携も解除
                                     if isGoogleCalendarLinked {
-                                        GoogleCalendarAPI.unlinkGoogleCalendar()
+                                        GoogleAuthService.unlinkGoogleCalendar()
                                         UserDefaults.standard.set(false, forKey: "isCalendarLinked")
                                         isGoogleCalendarLinked = false
                                         linkedAccountEmail = nil
@@ -123,7 +123,7 @@ struct SettingView: View {
                                             .foregroundColor(.secondary)
 
                                         Button("連携を解除") {
-                                            GoogleCalendarAPI.unlinkGoogleCalendar()
+                                            GoogleAuthService.unlinkGoogleCalendar()
                                             UserDefaults.standard.set(
                                                 false, forKey: "isCalendarLinked")
                                             isGoogleCalendarLinked = false
@@ -223,7 +223,7 @@ struct SettingView: View {
                     loadLinkedStatus()
                     // 連携状態の最新チェック
                     Task {
-                        await GoogleCalendarAPI.checkAndUpdateLinkingStatus()
+                        await GoogleAuthService.checkAndUpdateLinkingStatus()
                         // チェック後に最新状態を再読み込み
                         await MainActor.run {
                             loadLinkedStatus()

--- a/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
@@ -357,14 +357,14 @@ struct WorkoutRecordView: View {
                     isShowCalendarIntegration = true
                 }
                 Task {
-                    await GoogleCalendarAPI.checkAndUpdateLinkingStatus()
+                    await GoogleAuthService.checkAndUpdateLinkingStatus()
                 }
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active && isCalendarFeatureEnabled {
                 Task {
-                    await GoogleCalendarAPI.checkAndUpdateLinkingStatus()
+                    await GoogleAuthService.checkAndUpdateLinkingStatus()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- 487行の`GoogleCalendarAPI.swift`を責務ごとに3ファイルに分割
- 認証（OAuth/トークン管理）とAPI操作（CRUD）を明確に分離
- 統一的なエラーハンドリングを`CalendarAPIError`で実現
- 重複していたHTTPリクエスト/レスポンス処理を共通化

## 分割結果

| ファイル | 行数 | 責務 |
|---|---|---|
| `GoogleCalendarAPI.swift` | 211 | カレンダーイベントのCRUD |
| `GoogleAuthService.swift` | 223 | OAuth認証・トークン管理 |
| `CalendarAPIError.swift` | 32 | 統一エラー型 |

## 変更ファイル
- `GoogleCalendarIntegrationView.swift` - `linkGoogleCalendar` → `GoogleAuthService`
- `SettingView.swift` - `unlinkGoogleCalendar`, `checkAndUpdateLinkingStatus` → `GoogleAuthService`
- `WorkoutRecordView.swift` - `checkAndUpdateLinkingStatus` → `GoogleAuthService`

## 備考
- UIの変更なし（リファクタリングのみ）
- 既存のパブリックAPIシグネチャは維持（`createWorkoutEvent`, `fetchEvents`等）
- `CalendarAPIError`により将来のユニットテストが容易に

## Test plan
- [x] swift-formatでフォーマット確認済み
- [x] ビルド成功（新規エラーなし）
- [ ] 動作確認：カレンダー連携・解除・イベント作成/更新が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)