### PR TITLE
feat(ui-tests): Add UI tests for main screens using PageObject pattern

### DIFF
--- a/TrackFit/Views/ContentView.swift
+++ b/TrackFit/Views/ContentView.swift
@@ -29,16 +29,24 @@ struct ContentView: View {
                 Tab("ホーム", systemImage: "house", value: .home) {
                     HomeView()
                 }
+                .accessibilityIdentifier("homeTab")
+
                 Tab("トレーニング記録", systemImage: "timer", value: .workout) {
                     WorkoutRecordView()
                 }
+                .accessibilityIdentifier("workoutTab")
+
                 Tab(value: .history, role: .search) {
                     TrainingHistoryView(isSearchPresented: $isSearchPresented)
                 }
+                .accessibilityIdentifier("historyTab")
+
                 Tab("設定", systemImage: "gearshape", value: .setting) {
                     SettingView()
                 }
+                .accessibilityIdentifier("settingTab")
             }
+            .accessibilityIdentifier("mainTabView")
         }
     }
 }

--- a/TrackFit/Views/HomeView/HomeView.swift
+++ b/TrackFit/Views/HomeView/HomeView.swift
@@ -19,9 +19,11 @@ struct HomeView: View {
                 VStack(spacing: 20) {
                     // Streak Card
                     StreakCard(streak: viewModel.currentWeekStreak)
+                        .accessibilityIdentifier("streakCard")
 
                     // Heatmap
                     ActivityHeatmap(activityLog: viewModel.activityLog)
+                        .accessibilityIdentifier("activityHeatmap")
 
                     // Recent Activity
                     VStack(alignment: .leading, spacing: 12) {
@@ -34,6 +36,7 @@ struct HomeView: View {
                                 .foregroundStyle(.secondary)
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .padding()
+                                .accessibilityIdentifier("emptyRecentActivity")
                         } else {
                             ForEach(viewModel.recentWorkouts) { workout in
                                 NavigationLink(destination: WorkoutDetailView(workout: workout)) {
@@ -43,6 +46,7 @@ struct HomeView: View {
                             }
                         }
                     }
+                    .accessibilityIdentifier("recentActivitySection")
                 }
                 .padding()
             }

--- a/TrackFit/Views/SettingView/SettingView.swift
+++ b/TrackFit/Views/SettingView/SettingView.swift
@@ -173,6 +173,7 @@ struct SettingView: View {
                         Text("システム").tag(DisplayMode.system)
                     }
                     .pickerStyle(.automatic)
+                    .accessibilityIdentifier("themeColorPicker")
 
                     Button(action: {
                         isShowingExerciseManagement = true
@@ -187,6 +188,7 @@ struct SettingView: View {
                         }
                     }
                     .buttonStyle(PlainButtonStyle())
+                    .accessibilityIdentifier("exerciseManagementButton")
                 }
                 Section("About TrackFit") {
                     NavigationLink(destination: PrivacyPolicyView()) {
@@ -215,6 +217,7 @@ struct SettingView: View {
                         }
                     )
                     .frame(maxWidth: .infinity)
+                    .accessibilityIdentifier("versionInfo")
                 }
             }
             .navigationTitle("設定")

--- a/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
@@ -169,6 +169,7 @@ struct WorkoutRecordView: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
+                .accessibilityIdentifier("periodFilterPicker")
 
                 // MARK: ワークアウト種別切替
                 Picker("種別", selection: $selectedWorkoutType) {
@@ -177,6 +178,7 @@ struct WorkoutRecordView: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
+                .accessibilityIdentifier("workoutTypePicker")
 
                 // MARK: Googleカレンダー未連携バナー（カレンダー機能が有効な場合のみ表示）
                 /// 永続化している`isCalendarLinked`と`hasShownCalendarIntegration`をチェック
@@ -202,6 +204,7 @@ struct WorkoutRecordView: View {
                         runningListSection
                     }
                 }
+                .accessibilityIdentifier("workoutList")
                 .navigationTitle("トレーニング一覧")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -540,6 +543,7 @@ struct WorkoutRecordView: View {
                 )
             }
         }
+        .accessibilityIdentifier("addTrainingButton")
         .padding(.horizontal, 24)
         .padding(.bottom, 8)
         .zIndex(1)

--- a/TrackFitUITests/HomeViewUITests.swift
+++ b/TrackFitUITests/HomeViewUITests.swift
@@ -16,6 +16,7 @@ final class HomeViewUITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launch()
+        sleep(1)
 
         homePage = HomePage(app: app)
         tabBar = TabBar(app: app)

--- a/TrackFitUITests/HomeViewUITests.swift
+++ b/TrackFitUITests/HomeViewUITests.swift
@@ -1,0 +1,66 @@
+//
+//  HomeViewUITests.swift
+//  TrackFitUITests
+//
+//  ホーム画面のUIテスト
+//
+
+import XCTest
+
+final class HomeViewUITests: XCTestCase {
+    var app: XCUIApplication!
+    var homePage: HomePage!
+    var tabBar: TabBar!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+
+        homePage = HomePage(app: app)
+        tabBar = TabBar(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+        homePage = nil
+        tabBar = nil
+    }
+
+    // MARK: - 表示テスト
+
+    @MainActor
+    func testHomeViewIsDisplayed() throws {
+        // Given: アプリ起動時
+        // Then: ホーム画面が表示される
+        XCTAssertTrue(homePage.waitForPageLoad(), "ホーム画面が表示されるべき")
+        XCTAssertTrue(homePage.isDisplayed)
+    }
+
+    @MainActor
+    func testHomeContainsExpectedContent() throws {
+        // Given: ホーム画面
+        XCTAssertTrue(homePage.waitForPageLoad())
+
+        // Then: ホーム画面には何らかのコンテンツが表示される
+        // 「継続中」または「最近のアクティビティ」文字があることを確認
+        let hasStreakText = app.staticTexts["継続中"].exists
+        let hasRecentActivityText = app.staticTexts["最近のアクティビティ"].exists
+        XCTAssertTrue(hasStreakText || hasRecentActivityText, "ホーム画面にコンテンツが表示されるべき")
+    }
+
+    // MARK: - ナビゲーションテスト
+
+    @MainActor
+    func testNavigateToWorkoutFromHomeTab() throws {
+        // Given: ホーム画面
+        XCTAssertTrue(homePage.waitForPageLoad())
+
+        // When: トレーニング記録タブをタップ
+        tabBar.tapWorkoutTab()
+
+        // Then: トレーニング記録画面に遷移
+        let workoutPage = WorkoutRecordPage(app: app)
+        XCTAssertTrue(workoutPage.waitForPageLoad(), "トレーニング記録画面に遷移するべき")
+    }
+}

--- a/TrackFitUITests/Pages/Pages.swift
+++ b/TrackFitUITests/Pages/Pages.swift
@@ -1,0 +1,148 @@
+//
+//  Pages.swift
+//  TrackFitUITests
+//
+//  PageObjectパターンによる画面要素の抽象化
+//
+
+import XCTest
+
+// MARK: - Base Page
+
+/// 全ページの基底クラス
+class BasePage {
+    let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    /// 要素の存在を待機
+    func waitForElement(_ element: XCUIElement, timeout: TimeInterval = 5) -> Bool {
+        return element.waitForExistence(timeout: timeout)
+    }
+
+    /// アクセシビリティ識別子で要素を検索（any type）
+    func element(identifier: String) -> XCUIElement {
+        return app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+}
+
+// MARK: - Tab Bar
+
+/// タブバーのPageObject
+class TabBar: BasePage {
+    var homeTab: XCUIElement { app.buttons["ホーム"] }
+    var workoutTab: XCUIElement { app.buttons["トレーニング記録"] }
+    var settingTab: XCUIElement { app.buttons["設定"] }
+
+    func tapHomeTab() {
+        homeTab.tap()
+    }
+
+    func tapWorkoutTab() {
+        workoutTab.tap()
+    }
+
+    func tapSettingTab() {
+        settingTab.tap()
+    }
+}
+
+// MARK: - Home Page
+
+/// ホーム画面のPageObject
+class HomePage: BasePage {
+    var navigationTitle: XCUIElement { app.navigationBars["ホーム"] }
+    var streakCard: XCUIElement { element(identifier: "streakCard") }
+    var activityHeatmap: XCUIElement { element(identifier: "activityHeatmap") }
+    var recentActivitySection: XCUIElement { element(identifier: "recentActivitySection") }
+    var emptyRecentActivity: XCUIElement { element(identifier: "emptyRecentActivity") }
+
+    var isDisplayed: Bool {
+        return navigationTitle.exists
+    }
+
+    func waitForPageLoad(timeout: TimeInterval = 5) -> Bool {
+        return waitForElement(navigationTitle, timeout: timeout)
+    }
+}
+
+// MARK: - Workout Record Page
+
+/// トレーニング記録画面のPageObject
+class WorkoutRecordPage: BasePage {
+    var navigationTitle: XCUIElement { app.navigationBars["トレーニング一覧"] }
+    var periodFilterPicker: XCUIElement { element(identifier: "periodFilterPicker") }
+    var workoutTypePicker: XCUIElement { element(identifier: "workoutTypePicker") }
+    var workoutList: XCUIElement { element(identifier: "workoutList") }
+    var addTrainingButton: XCUIElement { element(identifier: "addTrainingButton") }
+
+    // フィルターボタン
+    var thisWeekFilter: XCUIElement { app.buttons["今週"] }
+    var lastWeekFilter: XCUIElement { app.buttons["先週"] }
+    var thisMonthFilter: XCUIElement { app.buttons["今月"] }
+    var allFilter: XCUIElement { app.buttons["全て"] }
+
+    // ワークアウト種別ボタン
+    var weightTrainingType: XCUIElement { app.buttons["筋トレ"] }
+    var runningType: XCUIElement { app.buttons["ランニング"] }
+
+    var isDisplayed: Bool {
+        return navigationTitle.exists
+    }
+
+    func waitForPageLoad(timeout: TimeInterval = 5) -> Bool {
+        return waitForElement(navigationTitle, timeout: timeout)
+    }
+
+    func selectThisWeek() {
+        thisWeekFilter.tap()
+    }
+
+    func selectLastWeek() {
+        lastWeekFilter.tap()
+    }
+
+    func selectThisMonth() {
+        thisMonthFilter.tap()
+    }
+
+    func selectAllPeriod() {
+        allFilter.tap()
+    }
+
+    func selectWeightTraining() {
+        weightTrainingType.tap()
+    }
+
+    func selectRunning() {
+        runningType.tap()
+    }
+
+    func tapAddButton() {
+        addTrainingButton.tap()
+    }
+}
+
+// MARK: - Setting Page
+
+/// 設定画面のPageObject
+class SettingPage: BasePage {
+    var navigationTitle: XCUIElement { app.navigationBars["設定"] }
+    var themeColorPicker: XCUIElement { element(identifier: "themeColorPicker") }
+    var exerciseManagementButton: XCUIElement { app.staticTexts["種目管理"] }
+    var versionInfo: XCUIElement { element(identifier: "versionInfo") }
+
+    var isDisplayed: Bool {
+        return navigationTitle.exists
+    }
+
+    func waitForPageLoad(timeout: TimeInterval = 5) -> Bool {
+        return waitForElement(navigationTitle, timeout: timeout)
+    }
+
+    func tapExerciseManagement() {
+        exerciseManagementButton.tap()
+    }
+}

--- a/TrackFitUITests/SettingViewUITests.swift
+++ b/TrackFitUITests/SettingViewUITests.swift
@@ -1,0 +1,67 @@
+//
+//  SettingViewUITests.swift
+//  TrackFitUITests
+//
+//  設定画面のUIテスト
+//
+
+import XCTest
+
+final class SettingViewUITests: XCTestCase {
+    var app: XCUIApplication!
+    var settingPage: SettingPage!
+    var tabBar: TabBar!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+
+        settingPage = SettingPage(app: app)
+        tabBar = TabBar(app: app)
+
+        // 設定タブへ移動
+        tabBar.tapSettingTab()
+        XCTAssertTrue(settingPage.waitForPageLoad())
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+        settingPage = nil
+        tabBar = nil
+    }
+
+    // MARK: - 表示テスト
+
+    @MainActor
+    func testSettingViewIsDisplayed() throws {
+        // Then: 設定画面が表示される
+        XCTAssertTrue(settingPage.isDisplayed, "設定画面が表示されるべき")
+    }
+
+    @MainActor
+    func testSettingContainsExpectedSections() throws {
+        // Then: 設定画面には期待されるセクションが表示される
+        let hasThemeText = app.staticTexts["テーマカラー"].exists
+        let hasExerciseText = app.staticTexts["種目管理"].exists
+        XCTAssertTrue(hasThemeText || hasExerciseText, "設定項目が表示されるべき")
+    }
+
+    @MainActor
+    func testExerciseManagementButtonExists() throws {
+        // Then: 種目管理ボタンが存在する
+        XCTAssertTrue(settingPage.exerciseManagementButton.exists, "種目管理ボタンが表示されるべき")
+    }
+
+    // MARK: - ナビゲーションテスト
+
+    @MainActor
+    func testNavigateBackToHome() throws {
+        // When: ホームタブをタップ
+        tabBar.tapHomeTab()
+
+        // Then: ホーム画面に戻る
+        let homePage = HomePage(app: app)
+        XCTAssertTrue(homePage.waitForPageLoad(), "ホーム画面に戻るべき")
+    }
+}

--- a/TrackFitUITests/SettingViewUITests.swift
+++ b/TrackFitUITests/SettingViewUITests.swift
@@ -16,6 +16,7 @@ final class SettingViewUITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launch()
+        sleep(1)
 
         settingPage = SettingPage(app: app)
         tabBar = TabBar(app: app)

--- a/TrackFitUITests/TrackFitUITests.swift
+++ b/TrackFitUITests/TrackFitUITests.swift
@@ -10,31 +10,15 @@ import XCTest
 final class TrackFitUITests: XCTestCase {
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
     @MainActor
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
             measure(metrics: [XCTApplicationLaunchMetric()]) {
                 XCUIApplication().launch()
             }

--- a/TrackFitUITests/UserFlowUITests.swift
+++ b/TrackFitUITests/UserFlowUITests.swift
@@ -1,0 +1,56 @@
+//
+//  UserFlowUITests.swift
+//  TrackFitUITests
+//
+//  ユーザーフロー（E2E）のUIテスト
+//
+
+import XCTest
+
+final class UserFlowUITests: XCTestCase {
+    var app: XCUIApplication!
+    var tabBar: TabBar!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+
+        tabBar = TabBar(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+        tabBar = nil
+    }
+
+    // MARK: - ワークアウト画面の操作フローテスト
+
+    @MainActor
+    func testWorkoutFilterAndTypeToggle() throws {
+        // トレーニング記録画面へ移動
+        tabBar.tapWorkoutTab()
+        let workoutPage = WorkoutRecordPage(app: app)
+        XCTAssertTrue(workoutPage.waitForPageLoad())
+
+        // フィルター切替
+        workoutPage.selectLastWeek()
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        workoutPage.selectThisMonth()
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        workoutPage.selectAllPeriod()
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        workoutPage.selectThisWeek()
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        // ワークアウト種別切替
+        workoutPage.selectRunning()
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        workoutPage.selectWeightTraining()
+        XCTAssertTrue(workoutPage.isDisplayed)
+    }
+}

--- a/TrackFitUITests/UserFlowUITests.swift
+++ b/TrackFitUITests/UserFlowUITests.swift
@@ -15,6 +15,7 @@ final class UserFlowUITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launch()
+        sleep(1)
 
         tabBar = TabBar(app: app)
     }

--- a/TrackFitUITests/WorkoutRecordViewUITests.swift
+++ b/TrackFitUITests/WorkoutRecordViewUITests.swift
@@ -16,6 +16,7 @@ final class WorkoutRecordViewUITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launch()
+        sleep(1)
 
         workoutPage = WorkoutRecordPage(app: app)
         tabBar = TabBar(app: app)

--- a/TrackFitUITests/WorkoutRecordViewUITests.swift
+++ b/TrackFitUITests/WorkoutRecordViewUITests.swift
@@ -1,0 +1,100 @@
+//
+//  WorkoutRecordViewUITests.swift
+//  TrackFitUITests
+//
+//  トレーニング記録画面のUIテスト
+//
+
+import XCTest
+
+final class WorkoutRecordViewUITests: XCTestCase {
+    var app: XCUIApplication!
+    var workoutPage: WorkoutRecordPage!
+    var tabBar: TabBar!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+
+        workoutPage = WorkoutRecordPage(app: app)
+        tabBar = TabBar(app: app)
+
+        // トレーニング記録タブへ移動
+        tabBar.tapWorkoutTab()
+        XCTAssertTrue(workoutPage.waitForPageLoad())
+    }
+
+    override func tearDownWithError() throws {
+        app = nil
+        workoutPage = nil
+        tabBar = nil
+    }
+
+    // MARK: - 表示テスト
+
+    @MainActor
+    func testWorkoutRecordViewIsDisplayed() throws {
+        // Then: トレーニング記録画面が表示される
+        XCTAssertTrue(workoutPage.isDisplayed, "トレーニング記録画面が表示されるべき")
+    }
+
+    @MainActor
+    func testPeriodFilterPickerExists() throws {
+        // Then: 期間フィルターPickerが存在する
+        XCTAssertTrue(workoutPage.thisWeekFilter.exists, "今週フィルターが表示されるべき")
+        XCTAssertTrue(workoutPage.lastWeekFilter.exists, "先週フィルターが表示されるべき")
+        XCTAssertTrue(workoutPage.thisMonthFilter.exists, "今月フィルターが表示されるべき")
+        XCTAssertTrue(workoutPage.allFilter.exists, "全てフィルターが表示されるべき")
+    }
+
+    @MainActor
+    func testWorkoutTypePickerExists() throws {
+        // Then: ワークアウト種別Pickerが存在する
+        XCTAssertTrue(workoutPage.weightTrainingType.exists, "筋トレタイプが表示されるべき")
+        XCTAssertTrue(workoutPage.runningType.exists, "ランニングタイプが表示されるべき")
+    }
+
+    @MainActor
+    func testAddButtonExists() throws {
+        // Then: 追加ボタンが存在する
+        XCTAssertTrue(workoutPage.addTrainingButton.exists, "追加ボタンが表示されるべき")
+    }
+
+    // MARK: - フィルター切替テスト
+
+    @MainActor
+    func testSwitchPeriodFilter() throws {
+        // When: 先週フィルターをタップ
+        workoutPage.selectLastWeek()
+
+        // Then: 画面がクラッシュせず表示される
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        // When: 今月フィルターをタップ
+        workoutPage.selectThisMonth()
+
+        // Then: 画面がクラッシュせず表示される
+        XCTAssertTrue(workoutPage.isDisplayed)
+    }
+
+    // MARK: - ワークアウト種別切替テスト
+
+    @MainActor
+    func testSwitchWorkoutType() throws {
+        // Given: 初期状態は筋トレ
+        XCTAssertTrue(workoutPage.weightTrainingType.exists)
+
+        // When: ランニングに切替
+        workoutPage.selectRunning()
+
+        // Then: 画面がクラッシュせず表示される
+        XCTAssertTrue(workoutPage.isDisplayed)
+
+        // When: 筋トレに戻す
+        workoutPage.selectWeightTraining()
+
+        // Then: 画面がクラッシュせず表示される
+        XCTAssertTrue(workoutPage.isDisplayed)
+    }
+}


### PR DESCRIPTION
## Summary
Issue #121の対応として、主要画面のUIテストを追加しました。

## Changes
- **アクセシビリティ識別子の追加**: 主要ビュー（ContentView、HomeView、WorkoutRecordView、SettingView）にUIテスト用の識別子を追加
- **PageObjectパターン**: `Pages.swift`で各画面のページオブジェクトを定義（TabBar、HomePage、WorkoutRecordPage、SettingPage）
- **UIテストファイル追加**: 
  - `HomeViewUITests.swift`: ホーム画面の表示・ナビゲーションテスト
  - `WorkoutRecordViewUITests.swift`: フィルター切替・ワークアウト種別切替テスト
  - `SettingViewUITests.swift`: 設定項目の表示テスト
  - `UserFlowUITests.swift`: E2Eワークアウトフローテスト

## Test Results
- 全19テストがパス ✅

## Related Issues
Closes #121