### PR TITLE
docs: 公開メソッドにドキュメンテーションコメントを追加 (#120)

### DIFF
--- a/TrackFit/Models/Exercise.swift
+++ b/TrackFit/Models/Exercise.swift
@@ -31,6 +31,7 @@ class Exercise: Identifiable {
         self.updatedAt = Date()
     }
 
+    /// 種目の情報を更新し、更新日時を記録する
     func updateExercise(name: String, category: String, memo: String, isRunning: Bool = false) {
         self.name = name
         self.category = category

--- a/TrackFit/Models/WorkoutRecord.swift
+++ b/TrackFit/Models/WorkoutRecord.swift
@@ -29,7 +29,7 @@ class WorkoutRecord: Identifiable {
     var distance: Double?  // km
     var durationSeconds: Int?  // 秒
 
-    // 筋トレ用イニシャライザ
+    /// 筋トレ用イニシャライザ（ランニング関連プロパティはnilで初期化）
     init(exerciseName: String, weight: Double, reps: Int, sets: Int) {
         self.exerciseName = exerciseName
         self.isRunning = false
@@ -40,7 +40,7 @@ class WorkoutRecord: Identifiable {
         self.durationSeconds = nil
     }
 
-    // ランニング用イニシャライザ
+    /// ランニング用イニシャライザ（筋トレ関連プロパティはnilで初期化）
     init(exerciseName: String, distance: Double, durationSeconds: Int) {
         self.exerciseName = exerciseName
         self.isRunning = true
@@ -51,7 +51,7 @@ class WorkoutRecord: Identifiable {
         self.durationSeconds = durationSeconds
     }
 
-    // ペース計算（分/km）
+    /// ランニングペースを「M:SS /km」形式の文字列で返す
     var paceString: String {
         guard let distance = distance, let duration = durationSeconds, distance > 0 else {
             return "--:--"
@@ -62,7 +62,7 @@ class WorkoutRecord: Identifiable {
         return String(format: "%d:%02d /km", minutes, seconds)
     }
 
-    // 時間フォーマット
+    /// 所要時間を「H:MM:SS」または「MM:SS」形式の文字列で返す
     var durationString: String {
         guard let duration = durationSeconds else { return "--:--:--" }
         let hours = duration / 3600

--- a/TrackFit/Services/AdMobService.swift
+++ b/TrackFit/Services/AdMobService.swift
@@ -26,6 +26,7 @@ class AdMobService: NSObject, ObservableObject {
         }
     }
 
+    /// Google Mobile Ads SDKを初期化する（重複呼び出しは無視される）
     func initializeAdMob() {
         if isInitialized { return }
         isInitialized = true
@@ -37,6 +38,7 @@ class AdMobService: NSObject, ObservableObject {
         }
     }
 
+    /// Info.plistからAdMobアプリIDを取得する
     func getAppID() -> String {
         guard
             let appID = Bundle.main.object(forInfoDictionaryKey: "GADApplicationIdentifier")
@@ -50,6 +52,7 @@ class AdMobService: NSObject, ObservableObject {
         return appID
     }
 
+    /// テスト用バナー広告ユニットIDを取得する（フォールバック付き）
     func getTestAdUnitID() -> String {
         guard
             let testID = Bundle.main.object(forInfoDictionaryKey: "ADMOB_BANNER_UNIT_ID_TEST")
@@ -64,6 +67,7 @@ class AdMobService: NSObject, ObservableObject {
         return testID
     }
 
+    /// 本番用バナー広告ユニットIDを取得する
     func getProductionAdUnitID() -> String {
         guard
             let prodID = Bundle.main.object(forInfoDictionaryKey: "ADMOB_BANNER_UNIT_ID_PROD")
@@ -77,6 +81,7 @@ class AdMobService: NSObject, ObservableObject {
         return prodID
     }
 
+    /// 現在のビルド構成に応じた広告ユニットIDを返す（Debug: テスト用、Release: 本番用）
     func getCurrentAdUnitID() -> String {
         #if DEBUG
             return getTestAdUnitID()

--- a/TrackFit/ViewModels/ExerciseViewModel.swift
+++ b/TrackFit/ViewModels/ExerciseViewModel.swift
@@ -28,6 +28,7 @@ class ExerciseViewModel: ObservableObject {
         // onAppearで呼ばれるため、ここでは不要
     }
 
+    /// SwiftDataから全種目を取得し、名前順にソートして保持する
     func fetchExercises() {
         do {
             let descriptor = FetchDescriptor<Exercise>(
@@ -42,6 +43,7 @@ class ExerciseViewModel: ObservableObject {
         }
     }
 
+    /// 新しいトレーニング種目を作成して永続化する
     func addExercise(name: String, category: String, memo: String = "", isRunning: Bool = false) {
         let newExercise = Exercise(name: name, category: category, memo: memo, isRunning: isRunning)
         modelContext.insert(newExercise)
@@ -50,6 +52,7 @@ class ExerciseViewModel: ObservableObject {
         // シートのonDismissでfetchExercises()を呼び出す
     }
 
+    /// 既存の種目情報を更新して永続化する
     func updateExercise(
         _ exercise: Exercise, name: String, category: String, memo: String, isRunning: Bool = false
     ) {
@@ -59,6 +62,7 @@ class ExerciseViewModel: ObservableObject {
         // シートのonDismissでfetchExercises()を呼び出す
     }
 
+    /// 指定した種目を削除して永続化する
     func deleteExercise(_ exercise: Exercise) {
         modelContext.delete(exercise)
         saveContext()
@@ -66,6 +70,7 @@ class ExerciseViewModel: ObservableObject {
         // シートのonDismissでfetchExercises()を呼び出す
     }
 
+    /// IndexSetで指定された複数の種目を一括削除する
     func deleteExercises(at offsets: IndexSet) {
         for index in offsets {
             let exercise = exercises[index]
@@ -95,7 +100,7 @@ class ExerciseViewModel: ObservableObject {
         categories = Array(uniqueCategories).sorted()
     }
 
-    // カテゴリ別の種目を取得
+    /// 指定カテゴリに属する種目の一覧を返す
     func exercises(for category: String) -> [Exercise] {
         return exercises.filter { $0.category == category }
     }

--- a/TrackFit/ViewModels/HomeViewModel.swift
+++ b/TrackFit/ViewModels/HomeViewModel.swift
@@ -27,6 +27,11 @@ class HomeViewModel: ObservableObject {
     // ヒートマップ用データ (日付 -> 回数)
     @Published var activityLog: [Date: Int] = [:]
 
+    /// トレーニング・ランニングデータからホーム画面の統計情報を更新する
+    ///
+    /// - Parameters:
+    ///   - workouts: 集計対象のトレーニング記録
+    ///   - runningRecords: 集計対象のランニング記録
     func updateStats(workouts: [DailyWorkout], runningRecords: [RunningRecord] = []) {
         self.recentWorkouts = Array(workouts.sorted(by: { $0.startDate > $1.startDate }).prefix(5))
         self.currentWeekStreak = calculateStreak(workouts: workouts, runningRecords: runningRecords)


### PR DESCRIPTION
## Summary
- HomeViewModel, ExerciseViewModel, Exercise, WorkoutRecord, AdMobServiceの公開メソッド・計算プロパティにSwiftDocコメントを追加
- PR #139（クラスレベルのドキュメント）と合わせて、Issue #120の全完了条件を満たす

## 対象ファイル（5ファイル）
- `HomeViewModel.swift` - `updateStats()` メソッド
- `ExerciseViewModel.swift` - CRUD系6メソッド（`fetchExercises`, `addExercise`, `updateExercise`, `deleteExercise`, `deleteExercises`, `exercises(for:)`）
- `Exercise.swift` - `updateExercise()` メソッド
- `WorkoutRecord.swift` - 2つのイニシャライザ、`paceString`, `durationString` 計算プロパティ
- `AdMobService.swift` - `initializeAdMob()`, `getAppID()`, `getTestAdUnitID()`, `getProductionAdUnitID()`, `getCurrentAdUnitID()`

## 備考
- UIの変更なし（ドキュメントコメントのみの追加）
- Closes #120

## Test plan
- [x] swift-formatでフォーマット確認済み
- [x] ドキュメントコメントのみの変更（ロジック変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)