### PR TITLE
feat: トレーニングカテゴリにアイコンと色を追加 (#93)

### DIFF
--- a/TrackFit/Enums/ExerciseCategoryIcon.swift
+++ b/TrackFit/Enums/ExerciseCategoryIcon.swift
@@ -1,0 +1,43 @@
+//
+//  ExerciseCategoryIcon.swift
+//  TrackFit
+//
+
+import SwiftUI
+
+/// トレーニングカテゴリに対応するSF Symbolsアイコンと色を提供するヘルパー
+///
+/// 定義済みの8カテゴリに対してアイコンと色をマッピングし、
+/// 未定義のカスタムカテゴリにはデフォルトのアイコン・色を返す。
+enum ExerciseCategoryIcon {
+
+    /// カテゴリ名に対応するSF Symbolsアイコン名を返す
+    static func icon(for category: String) -> String {
+        switch category {
+        case "胸": return "figure.strengthtraining.traditional"
+        case "背中": return "figure.rower"
+        case "肩": return "figure.boxing"
+        case "腕": return "dumbbell.fill"
+        case "脚": return "figure.step.training"
+        case "腹筋": return "figure.core.training"
+        case "有酸素": return "heart.circle.fill"
+        case "その他": return "ellipsis.circle.fill"
+        default: return "figure.mixed.cardio"
+        }
+    }
+
+    /// カテゴリ名に対応するテーマカラーを返す
+    static func color(for category: String) -> Color {
+        switch category {
+        case "胸": return .red
+        case "背中": return .blue
+        case "肩": return .orange
+        case "腕": return .purple
+        case "脚": return .green
+        case "腹筋": return .yellow
+        case "有酸素": return .pink
+        case "その他": return .gray
+        default: return .secondary
+        }
+    }
+}

--- a/TrackFit/Views/ExerciseManagementView.swift
+++ b/TrackFit/Views/ExerciseManagementView.swift
@@ -23,7 +23,15 @@ struct ExerciseManagementView: View {
             List {
                 if !exerciseViewModel.categories.isEmpty {
                     ForEach(exerciseViewModel.categories, id: \.self) { category in
-                        Section(category) {
+                        Section(
+                            header: HStack(spacing: 6) {
+                                Image(
+                                    systemName: ExerciseCategoryIcon.icon(for: category)
+                                )
+                                .foregroundColor(ExerciseCategoryIcon.color(for: category))
+                                Text(category)
+                            }
+                        ) {
                             ForEach(exerciseViewModel.exercises(for: category)) { exercise in
                                 ExerciseRowView(exercise: exercise) {
                                     exerciseViewModel.selectedExercise = exercise
@@ -177,22 +185,34 @@ struct ExerciseFormView: View {
                             columns: Array(repeating: GridItem(.flexible()), count: 4), spacing: 8
                         ) {
                             ForEach(commonCategories, id: \.self) { commonCategory in
+                                let isSelected = category == commonCategory
+                                let categoryColor = ExerciseCategoryIcon.color(
+                                    for: commonCategory)
                                 Button(action: {
                                     category = commonCategory
                                 }) {
-                                    Text(commonCategory)
-                                        .font(.caption)
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 6)
-                                        .frame(maxWidth: .infinity)
-                                        .background(
-                                            category == commonCategory
-                                                ? Color.accentColor : Color.gray.opacity(0.2)
+                                    VStack(spacing: 4) {
+                                        Image(
+                                            systemName: ExerciseCategoryIcon.icon(
+                                                for: commonCategory)
                                         )
+                                        .font(.title3)
                                         .foregroundColor(
-                                            category == commonCategory ? .white : .primary
+                                            isSelected ? .white : categoryColor
                                         )
-                                        .cornerRadius(8)
+                                        Text(commonCategory)
+                                            .font(.caption2)
+                                            .foregroundColor(
+                                                isSelected ? .white : .primary
+                                            )
+                                    }
+                                    .padding(.vertical, 8)
+                                    .frame(maxWidth: .infinity)
+                                    .background(
+                                        isSelected
+                                            ? categoryColor : categoryColor.opacity(0.1)
+                                    )
+                                    .cornerRadius(10)
                                 }
                                 .buttonStyle(PlainButtonStyle())
                             }

--- a/TrackFit/Views/ExerciseSelectionView.swift
+++ b/TrackFit/Views/ExerciseSelectionView.swift
@@ -71,7 +71,17 @@ struct ExerciseSelectionView: View {
                                 .padding()
                         } else {
                             ForEach(filteredCategories, id: \.self) { category in
-                                Section(category) {
+                                Section(
+                                    header: HStack(spacing: 6) {
+                                        Image(
+                                            systemName: ExerciseCategoryIcon.icon(
+                                                for: category)
+                                        )
+                                        .foregroundColor(
+                                            ExerciseCategoryIcon.color(for: category))
+                                        Text(category)
+                                    }
+                                ) {
                                     ForEach(exercisesForCategory(category)) { exercise in
                                         ExerciseSelectionRowView(exercise: exercise) {
                                             onExerciseSelected(exercise)

--- a/TrackFit/Views/TrainingHistoryView/TrainingHistoryView.swift
+++ b/TrackFit/Views/TrainingHistoryView/TrainingHistoryView.swift
@@ -98,7 +98,17 @@ struct TrainingHistoryView: View {
                 List {
                     if selectedHistoryType == .exercise {
                         ForEach(groupedExercises, id: \.category) { group in
-                            Section(header: Text(group.category)) {
+                            Section(
+                                header: HStack(spacing: 6) {
+                                    Image(
+                                        systemName: ExerciseCategoryIcon.icon(
+                                            for: group.category)
+                                    )
+                                    .foregroundColor(
+                                        ExerciseCategoryIcon.color(for: group.category))
+                                    Text(group.category)
+                                }
+                            ) {
                                 ForEach(group.exercises) { exercise in
                                     NavigationLink(
                                         destination: ExerciseDetailView(exercise: exercise)


### PR DESCRIPTION
## Summary
- トレーニングカテゴリ（胸・背中・肩・腕・脚・腹筋・有酸素・その他）にSF Symbolsアイコンとテーマカラーを追加
- `ExerciseCategoryIcon`ヘルパーを新規作成し、`RunType`パターンに合わせた設計
- カテゴリ選択ボタン、各画面のセクションヘッダーにアイコン+色を表示

## 変更箇所
| 画面 | 変更内容 |
|---|---|
| ExerciseFormView（種目追加/編集） | カテゴリ選択ボタンをアイコン+色付き背景に変更 |
| ExerciseManagementView（種目管理） | セクションヘッダーにカテゴリアイコンを追加 |
| ExerciseSelectionView（種目選択） | セクションヘッダーにカテゴリアイコンを追加 |
| TrainingHistoryView（履歴） | 種目タブのセクションヘッダーにカテゴリアイコンを追加 |

## カテゴリ別アイコン・色マッピング
| カテゴリ | SF Symbol | 色 |
|---|---|---|
| 胸 | figure.strengthtraining.traditional | 赤 |
| 背中 | figure.rower | 青 |
| 肩 | figure.boxing | オレンジ |
| 腕 | dumbbell.fill | 紫 |
| 脚 | figure.step.training | 緑 |
| 腹筋 | figure.core.training | 黄 |
| 有酸素 | heart.circle.fill | ピンク |
| その他 | ellipsis.circle.fill | グレー |
| カスタム | figure.mixed.cardio | セカンダリ |

## 新規ファイル
- `TrackFit/Enums/ExerciseCategoryIcon.swift`

## Test plan
- [x] ビルド成功確認済み
- [x] swift-formatでフォーマット確認済み
- [ ] 種目管理画面でカテゴリアイコンが表示されることを確認
- [ ] 種目追加フォームでカテゴリ選択ボタンにアイコンが表示されることを確認
- [ ] 種目選択画面でセクションヘッダーにアイコンが表示されることを確認
- [ ] 履歴画面の種目タブでセクションヘッダーにアイコンが表示されることを確認
- [ ] カスタムカテゴリにデフォルトアイコンが適用されることを確認

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)