### PR TITLE
feat: Apple純正カレンダー連携機能を追加 (#84)

### DIFF
--- a/TrackFit/Info.plist
+++ b/TrackFit/Info.plist
@@ -21,6 +21,8 @@
 	<string>$(ADMOB_BANNER_UNIT_ID_TEST)</string>
 	<key>ADMOB_BANNER_UNIT_ID_PROD</key>
 	<string>$(ADMOB_BANNER_UNIT_ID_PROD)</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>トレーニング記録をカレンダーに同期するために使用されます。</string>
 	<key>NSUserTrackingUsageDescription</key>
 	<string>お客様の興味関心に合わせた広告を表示するために使用されます。</string>
 	<key>SKAdNetworkItems</key>

--- a/TrackFit/Models/DailyWorkout.swift
+++ b/TrackFit/Models/DailyWorkout.swift
@@ -18,21 +18,28 @@ class DailyWorkout: Identifiable {
     var startDate: Date
     var endDate: Date
     var eventId: String?
+    var appleEventId: String?
 
     // その日実施したトレーニング一覧
     var records: [WorkoutRecord]
 
     // Googleカレンダー連携済みかどうか
     var isSyncedToCalendar: Bool = false
+    // Appleカレンダー連携済みかどうか
+    var isSyncedToAppleCalendar: Bool = false
 
     init(
         startDate: Date, endDate: Date, records: [WorkoutRecord], eventId: String? = nil,
-        isSyncedToCalendar: Bool
+        appleEventId: String? = nil,
+        isSyncedToCalendar: Bool = false,
+        isSyncedToAppleCalendar: Bool = false
     ) {
         self.startDate = startDate
         self.endDate = endDate
         self.records = records
         self.eventId = eventId
+        self.appleEventId = appleEventId
         self.isSyncedToCalendar = isSyncedToCalendar
+        self.isSyncedToAppleCalendar = isSyncedToAppleCalendar
     }
 }

--- a/TrackFit/Models/RunningRecord.swift
+++ b/TrackFit/Models/RunningRecord.swift
@@ -28,6 +28,9 @@ class RunningRecord: Identifiable {
     // Googleカレンダー連携
     var isSyncedToCalendar: Bool = false
     var eventId: String?
+    // Appleカレンダー連携
+    var isSyncedToAppleCalendar: Bool = false
+    var appleEventId: String?
 
     // MARK: - Computed Properties
 
@@ -76,7 +79,9 @@ class RunningRecord: Identifiable {
         averageHeartRate: Int? = nil,
         memo: String? = nil,
         isSyncedToCalendar: Bool = false,
-        eventId: String? = nil
+        eventId: String? = nil,
+        isSyncedToAppleCalendar: Bool = false,
+        appleEventId: String? = nil
     ) {
         self.date = date
         self.distance = distance
@@ -88,5 +93,7 @@ class RunningRecord: Identifiable {
         self.createdAt = Date()
         self.isSyncedToCalendar = isSyncedToCalendar
         self.eventId = eventId
+        self.isSyncedToAppleCalendar = isSyncedToAppleCalendar
+        self.appleEventId = appleEventId
     }
 }

--- a/TrackFit/Services/AppleCalendarError.swift
+++ b/TrackFit/Services/AppleCalendarError.swift
@@ -1,0 +1,27 @@
+//
+//  AppleCalendarError.swift
+//  TrackFit
+//
+
+import Foundation
+
+/// Appleカレンダー（EventKit）操作で発生するエラーを統一的に扱うエラー型
+enum AppleCalendarError: LocalizedError {
+    case accessDenied
+    case calendarNotFound
+    case eventNotFound
+    case saveFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .accessDenied:
+            return "カレンダーへのアクセスが拒否されています。設定アプリから許可してください。"
+        case .calendarNotFound:
+            return "指定されたカレンダーが見つかりません。"
+        case .eventNotFound:
+            return "更新対象のイベントが見つかりません。"
+        case .saveFailed(let underlying):
+            return "イベントの保存に失敗しました: \(underlying.localizedDescription)"
+        }
+    }
+}

--- a/TrackFit/Services/AppleCalendarService.swift
+++ b/TrackFit/Services/AppleCalendarService.swift
@@ -1,0 +1,186 @@
+//
+//  AppleCalendarService.swift
+//  TrackFit
+//
+
+import EventKit
+import Foundation
+
+/// Apple純正カレンダー（EventKit）との連携を管理するサービス
+///
+/// EKEventStoreを使用してカレンダーイベントのCRUD操作とパーミッション管理を行う。
+/// Googleカレンダー連携と並行して動作する。
+struct AppleCalendarService {
+
+    // MARK: - Shared Event Store
+
+    /// アプリ全体で共有するEKEventStoreインスタンス
+    static let eventStore = EKEventStore()
+
+    // MARK: - Permission
+
+    /// カレンダーアクセス権限をリクエスト
+    static func requestAccess() async throws -> Bool {
+        return try await eventStore.requestFullAccessToEvents()
+    }
+
+    /// 現在のカレンダーアクセス権限ステータスを返す
+    static var authorizationStatus: EKAuthorizationStatus {
+        EKEventStore.authorizationStatus(for: .event)
+    }
+
+    /// フルアクセスが許可されているかどうか
+    static var hasFullAccess: Bool {
+        authorizationStatus == .fullAccess
+    }
+
+    // MARK: - Calendar Selection
+
+    /// ユーザーが書き込み可能なカレンダー一覧を取得
+    static func writableCalendars() -> [EKCalendar] {
+        eventStore.calendars(for: .event).filter { $0.allowsContentModifications }
+    }
+
+    /// デフォルトカレンダーを取得
+    static func defaultCalendar() -> EKCalendar? {
+        eventStore.defaultCalendarForNewEvents
+    }
+
+    /// 保存されたカレンダーIDからEKCalendarを復元。見つからなければdefaultを返す
+    static func calendar(forIdentifier identifier: String?) -> EKCalendar? {
+        if let id = identifier, !id.isEmpty,
+            let cal = eventStore.calendar(withIdentifier: id)
+        {
+            return cal
+        }
+        return defaultCalendar()
+    }
+
+    // MARK: - Create Event (DailyWorkout)
+
+    /// DailyWorkoutからAppleカレンダーイベントを作成
+    /// - Returns: 作成されたイベントのeventIdentifier
+    static func createWorkoutEvent(
+        workout: DailyWorkout,
+        calendarIdentifier: String? = nil
+    ) throws -> String {
+        guard let calendar = calendar(forIdentifier: calendarIdentifier) else {
+            throw AppleCalendarError.calendarNotFound
+        }
+
+        let event = EKEvent(eventStore: eventStore)
+        event.title = "トレーニング"
+        event.startDate = workout.startDate
+        event.endDate = workout.endDate
+        event.calendar = calendar
+        event.notes = buildWorkoutDescription(workout: workout)
+
+        try eventStore.save(event, span: .thisEvent)
+        return event.eventIdentifier
+    }
+
+    // MARK: - Update Event (DailyWorkout)
+
+    /// 既存のAppleカレンダーイベントを更新
+    static func updateWorkoutEvent(
+        eventIdentifier: String,
+        workout: DailyWorkout,
+        calendarIdentifier: String? = nil
+    ) throws {
+        guard let event = eventStore.event(withIdentifier: eventIdentifier) else {
+            throw AppleCalendarError.eventNotFound
+        }
+
+        event.title = "トレーニング"
+        event.startDate = workout.startDate
+        event.endDate = workout.endDate
+        event.notes = buildWorkoutDescription(workout: workout)
+
+        if let calId = calendarIdentifier, !calId.isEmpty,
+            let cal = eventStore.calendar(withIdentifier: calId)
+        {
+            event.calendar = cal
+        }
+
+        try eventStore.save(event, span: .thisEvent)
+    }
+
+    // MARK: - Create Event (RunningRecord)
+
+    /// RunningRecordからAppleカレンダーイベントを作成
+    /// - Returns: 作成されたイベントのeventIdentifier
+    static func createRunningEvent(
+        record: RunningRecord,
+        calendarIdentifier: String? = nil
+    ) throws -> String {
+        guard let calendar = calendar(forIdentifier: calendarIdentifier) else {
+            throw AppleCalendarError.calendarNotFound
+        }
+
+        let event = EKEvent(eventStore: eventStore)
+        event.title = "ランニング（\(record.runType.rawValue)）"
+        event.startDate = record.date
+        event.endDate = record.date.addingTimeInterval(record.duration)
+        event.calendar = calendar
+        event.notes = buildRunningDescription(record: record)
+
+        try eventStore.save(event, span: .thisEvent)
+        return event.eventIdentifier
+    }
+
+    // MARK: - Update Event (RunningRecord)
+
+    /// 既存のランニングイベントを更新
+    static func updateRunningEvent(
+        eventIdentifier: String,
+        record: RunningRecord,
+        calendarIdentifier: String? = nil
+    ) throws {
+        guard let event = eventStore.event(withIdentifier: eventIdentifier) else {
+            throw AppleCalendarError.eventNotFound
+        }
+
+        event.title = "ランニング（\(record.runType.rawValue)）"
+        event.startDate = record.date
+        event.endDate = record.date.addingTimeInterval(record.duration)
+        event.notes = buildRunningDescription(record: record)
+
+        try eventStore.save(event, span: .thisEvent)
+    }
+
+    // MARK: - Private Helpers
+
+    /// ワークアウト記録のdescriptionテキストを生成
+    private static func buildWorkoutDescription(workout: DailyWorkout) -> String {
+        workout.records.map { record in
+            if record.isRunning {
+                return """
+                    種目: \(record.exerciseName)
+                    距離: \(String(format: "%.2f", record.distance ?? 0)) km
+                    時間: \(record.durationString)
+                    """
+            } else {
+                return """
+                    種目: \(record.exerciseName)
+                    重量: \(String(format: "%.1f", record.weight ?? 0)) kg
+                    セット数: \(record.sets ?? 0)
+                    回数: \(record.reps ?? 0)
+                    """
+            }
+        }.joined(separator: "\n\n")
+    }
+
+    /// ランニング記録のdescriptionテキストを生成
+    private static func buildRunningDescription(record: RunningRecord) -> String {
+        var lines: [String] = [
+            "種別: \(record.runType.rawValue)",
+            "距離: \(String(format: "%.2f", record.distance)) km",
+            "時間: \(record.durationString)",
+            "ペース: \(record.paceString)",
+        ]
+        if let memo = record.memo, !memo.isEmpty {
+            lines.append("メモ: \(memo)")
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/TrackFit/ViewModels/RunningViewModel.swift
+++ b/TrackFit/ViewModels/RunningViewModel.swift
@@ -49,8 +49,9 @@ class RunningViewModel: ObservableObject {
 
     // MARK: - Methods
 
-    /// ランニング記録を保存
-    func saveRunningRecord(context: ModelContext) {
+    /// ランニング記録を保存し、作成したレコードを返す
+    @discardableResult
+    func saveRunningRecord(context: ModelContext) -> RunningRecord {
         let record = RunningRecord(
             date: selectedDate,
             distance: distance,
@@ -60,6 +61,7 @@ class RunningViewModel: ObservableObject {
         )
         context.insert(record)
         resetForm()
+        return record
     }
 
     /// フォームをリセット

--- a/TrackFit/Views/SettingView/AppleCalendarSettingSection.swift
+++ b/TrackFit/Views/SettingView/AppleCalendarSettingSection.swift
@@ -1,0 +1,124 @@
+//
+//  AppleCalendarSettingSection.swift
+//  TrackFit
+//
+
+import EventKit
+import SwiftUI
+
+/// Appleカレンダー連携設定のセクションビュー
+struct AppleCalendarSettingSection: View {
+    @AppStorage("isAppleCalendarLinked") private var isAppleCalendarLinked: Bool = false
+    @AppStorage("appleCalendarIdentifier") private var appleCalendarIdentifier: String = ""
+    @State private var writableCalendars: [EKCalendar] = []
+    @State private var showPermissionAlert = false
+
+    var body: some View {
+        HStack(alignment: .top) {
+            Text("Appleカレンダー")
+            Spacer()
+            if isAppleCalendarLinked {
+                linkedView
+            } else {
+                Button("連携する") {
+                    Task { await requestAndLink() }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .onAppear {
+            if isAppleCalendarLinked {
+                refreshPermissionState()
+                loadCalendars()
+            }
+        }
+        .alert("カレンダーへのアクセスが必要です", isPresented: $showPermissionAlert) {
+            Button("設定を開く") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("キャンセル", role: .cancel) {}
+        } message: {
+            Text("設定アプリからTrackFitのカレンダーアクセスを許可してください。")
+        }
+    }
+
+    // MARK: - 連携中の表示
+    private var linkedView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 12) {
+                Image(systemName: "calendar.circle.fill")
+                    .foregroundColor(.green)
+                    .font(.title3)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Appleカレンダーと連携中")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.green)
+
+                    // カレンダー選択Picker
+                    if !writableCalendars.isEmpty {
+                        Picker("カレンダー", selection: $appleCalendarIdentifier) {
+                            ForEach(writableCalendars, id: \.calendarIdentifier) { cal in
+                                HStack {
+                                    Circle()
+                                        .fill(Color(cgColor: cal.cgColor))
+                                        .frame(width: 12, height: 12)
+                                    Text(cal.title)
+                                }
+                                .tag(cal.calendarIdentifier)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    }
+
+                    Button("連携を解除") {
+                        isAppleCalendarLinked = false
+                        appleCalendarIdentifier = ""
+                    }
+                    .font(.caption)
+                    .foregroundColor(.red)
+                }
+            }
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func requestAndLink() async {
+        do {
+            let granted = try await AppleCalendarService.requestAccess()
+            await MainActor.run {
+                if granted {
+                    isAppleCalendarLinked = true
+                    loadCalendars()
+                    if appleCalendarIdentifier.isEmpty,
+                        let defaultCal = AppleCalendarService.defaultCalendar()
+                    {
+                        appleCalendarIdentifier = defaultCal.calendarIdentifier
+                    }
+                } else {
+                    showPermissionAlert = true
+                }
+            }
+        } catch {
+            await MainActor.run {
+                showPermissionAlert = true
+            }
+        }
+    }
+
+    private func loadCalendars() {
+        writableCalendars = AppleCalendarService.writableCalendars()
+    }
+
+    /// 権限が後から取り消されていないかチェック
+    private func refreshPermissionState() {
+        if !AppleCalendarService.hasFullAccess {
+            isAppleCalendarLinked = false
+            appleCalendarIdentifier = ""
+        }
+    }
+}

--- a/TrackFit/Views/SettingView/SettingView.swift
+++ b/TrackFit/Views/SettingView/SettingView.swift
@@ -89,7 +89,7 @@ struct SettingView: View {
                         Toggle("", isOn: $isCalendarFeatureEnabled)
                             .onChange(of: isCalendarFeatureEnabled) { _, newValue in
                                 if !newValue {
-                                    // 機能をオフにした場合、連携も解除
+                                    // 機能をオフにした場合、全連携を解除
                                     if isGoogleCalendarLinked {
                                         GoogleAuthService.unlinkGoogleCalendar()
                                         UserDefaults.standard.set(false, forKey: "isCalendarLinked")
@@ -97,12 +97,21 @@ struct SettingView: View {
                                         linkedAccountEmail = nil
                                         accessToken = nil
                                     }
+                                    // Appleカレンダー連携も解除
+                                    UserDefaults.standard.set(
+                                        false, forKey: "isAppleCalendarLinked")
+                                    UserDefaults.standard.set(
+                                        "", forKey: "appleCalendarIdentifier")
                                 }
                             }
                     }
 
-                    // カレンダー機能が有効な場合のみGoogleカレンダー連携を表示
+                    // カレンダー機能が有効な場合のみ連携オプションを表示
                     if isCalendarFeatureEnabled {
+                        // Appleカレンダー連携
+                        AppleCalendarSettingSection()
+
+                        // Googleカレンダー連携
                         HStack {
                             Text("Googleカレンダー")
                             Spacer()

--- a/TrackFit/Views/WorkoutRecordView/RunningRecordFormView.swift
+++ b/TrackFit/Views/WorkoutRecordView/RunningRecordFormView.swift
@@ -13,6 +13,8 @@ struct RunningRecordFormView: View {
     @Environment(\.modelContext) private var context
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = RunningViewModel()
+    @AppStorage("isAppleCalendarLinked") private var isAppleCalendarLinked: Bool = false
+    @AppStorage("appleCalendarIdentifier") private var appleCalendarIdentifier: String = ""
 
     // 編集モード用
     var editingRecord: RunningRecord?
@@ -145,12 +147,52 @@ struct RunningRecordFormView: View {
     }
 
     private func saveRecord() {
+        let record: RunningRecord
         if let existing = editingRecord {
             viewModel.updateRunningRecord(existing)
+            record = existing
         } else {
-            viewModel.saveRunningRecord(context: context)
+            record = viewModel.saveRunningRecord(context: context)
         }
+
+        // Apple Calendar同期
+        if isAppleCalendarLinked {
+            syncRunningToAppleCalendar(record: record)
+            do {
+                try context.save()
+            } catch {
+                #if DEBUG
+                    print("データ保存エラー: \(error.localizedDescription)")
+                #endif
+            }
+        }
+
         dismiss()
+    }
+
+    private func syncRunningToAppleCalendar(record: RunningRecord) {
+        let calId = appleCalendarIdentifier.isEmpty ? nil : appleCalendarIdentifier
+        do {
+            if let existingId = record.appleEventId {
+                try AppleCalendarService.updateRunningEvent(
+                    eventIdentifier: existingId,
+                    record: record,
+                    calendarIdentifier: calId
+                )
+            } else {
+                let newId = try AppleCalendarService.createRunningEvent(
+                    record: record,
+                    calendarIdentifier: calId
+                )
+                record.appleEventId = newId
+            }
+            record.isSyncedToAppleCalendar = true
+        } catch {
+            record.isSyncedToAppleCalendar = false
+            #if DEBUG
+                print("Apple Calendar同期エラー: \(error.localizedDescription)")
+            #endif
+        }
     }
 }
 

--- a/TrackFit/Views/WorkoutRecordView/RunningRow.swift
+++ b/TrackFit/Views/WorkoutRecordView/RunningRow.swift
@@ -23,7 +23,7 @@ struct RunningRow: View {
 
                 // カレンダー同期状態
                 if isCalendarFeatureEnabled {
-                    if record.isSyncedToCalendar {
+                    if record.isSyncedToCalendar || record.isSyncedToAppleCalendar {
                         HStack(spacing: 4) {
                             Image(systemName: "calendar.badge.checkmark")
                             Text("連携済み")

--- a/TrackFit/Views/WorkoutRecordView/WorkoutRow.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutRow.swift
@@ -24,7 +24,7 @@ struct WorkoutRow: View {
                         .font(.footnote)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                    } else if daily.isSyncedToCalendar {
+                    } else if daily.isSyncedToCalendar || daily.isSyncedToAppleCalendar {
                         HStack(spacing: 15) {
                             Image(systemName: "calendar.badge.checkmark")
                             Text("連携済み")

--- a/TrackFit/Views/WorkoutRecordView/WorkoutSheetView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutSheetView.swift
@@ -24,6 +24,8 @@ struct WorkoutSheetView: View {
 
     @Environment(\.modelContext) private var context
     @AppStorage("isCalendarLinked") private var isCalendarLinked: Bool = false
+    @AppStorage("isAppleCalendarLinked") private var isAppleCalendarLinked: Bool = false
+    @AppStorage("appleCalendarIdentifier") private var appleCalendarIdentifier: String = ""
 
     // 2カラムのレイアウトでカード表示
     private let columns = [
@@ -183,7 +185,7 @@ struct WorkoutSheetView: View {
 
     // MARK: - 保存処理
     private func handleSave() {
-        if isCalendarLinked {
+        if isCalendarLinked || isAppleCalendarLinked {
             saveWithCalendarSync()
         } else {
             saveWithoutCalendar()
@@ -195,43 +197,64 @@ struct WorkoutSheetView: View {
             name: .didStartSyncingWorkout, object: daily.id)
         dismiss()
         Task { @MainActor in
-            var isSaveLatestWorkout: Bool
+            // Google Calendar同期
+            if isCalendarLinked {
+                var isSaveLatestWorkout: Bool
 
-            if daily.eventId == nil {
-                isSaveLatestWorkout = await viewModel.createEvent(dailyWorkout: daily)
-                if isSaveLatestWorkout, let newEventId = viewModel.eventId {
-                    daily.eventId = newEventId
-                }
-            } else {
-                isSaveLatestWorkout = await viewModel.updateEvent(dailyWorkout: daily)
-            }
-
-            if isSaveLatestWorkout {
-                daily.isSyncedToCalendar = true
-                do {
-                    try context.save()
-                } catch {
-                    #if DEBUG
-                        print("データ保存エラー: \(error.localizedDescription)")
-                    #endif
-                    daily.isSyncedToCalendar = false
-                }
-            } else {
-                daily.isSyncedToCalendar = false
-                do {
-                    try context.save()
-                } catch {
-                    #if DEBUG
-                        print("データ保存エラー: \(error.localizedDescription)")
-                    #endif
+                if daily.eventId == nil {
+                    isSaveLatestWorkout = await viewModel.createEvent(dailyWorkout: daily)
+                    if isSaveLatestWorkout, let newEventId = viewModel.eventId {
+                        daily.eventId = newEventId
+                    }
+                } else {
+                    isSaveLatestWorkout = await viewModel.updateEvent(dailyWorkout: daily)
                 }
 
-                if let errorMsg = viewModel.errorMessage {
+                daily.isSyncedToCalendar = isSaveLatestWorkout
+
+                if !isSaveLatestWorkout, let errorMsg = viewModel.errorMessage {
                     #if DEBUG
                         print("Google Calendar同期エラー: \(errorMsg)")
                     #endif
                 }
             }
+
+            // Apple Calendar同期
+            if isAppleCalendarLinked {
+                do {
+                    let calId =
+                        appleCalendarIdentifier.isEmpty ? nil : appleCalendarIdentifier
+                    if let existingId = daily.appleEventId {
+                        try AppleCalendarService.updateWorkoutEvent(
+                            eventIdentifier: existingId,
+                            workout: daily,
+                            calendarIdentifier: calId
+                        )
+                    } else {
+                        let newId = try AppleCalendarService.createWorkoutEvent(
+                            workout: daily,
+                            calendarIdentifier: calId
+                        )
+                        daily.appleEventId = newId
+                    }
+                    daily.isSyncedToAppleCalendar = true
+                } catch {
+                    daily.isSyncedToAppleCalendar = false
+                    #if DEBUG
+                        print("Apple Calendar同期エラー: \(error.localizedDescription)")
+                    #endif
+                }
+            }
+
+            // データ保存
+            do {
+                try context.save()
+            } catch {
+                #if DEBUG
+                    print("データ保存エラー: \(error.localizedDescription)")
+                #endif
+            }
+
             NotificationCenter.default.post(
                 name: .didFinishSyncingWorkout, object: daily.id)
         }
@@ -239,6 +262,7 @@ struct WorkoutSheetView: View {
 
     private func saveWithoutCalendar() {
         daily.isSyncedToCalendar = false
+        daily.isSyncedToAppleCalendar = false
         do {
             try context.save()
         } catch {


### PR DESCRIPTION
## Summary
- EventKitフレームワークを使用したApple純正カレンダーとの連携機能を実装
- 既存のGoogleカレンダー連携と並行して動作（両方同時に有効化可能）
- ランニング記録のApple Calendar同期も対応（Google未対応の新機能）

## 新規ファイル（3ファイル）
| ファイル | 内容 |
|---|---|
| `AppleCalendarService.swift` | EKEventStoreベースの権限管理・イベントCRUD |
| `AppleCalendarError.swift` | AppleCalendar固有のエラー型 |
| `AppleCalendarSettingSection.swift` | 設定画面のAppleカレンダー連携UIコンポーネント |

## 変更ファイル（9ファイル）
| ファイル | 変更内容 |
|---|---|
| `Info.plist` | `NSCalendarsFullAccessUsageDescription`追加 |
| `DailyWorkout.swift` | `appleEventId`, `isSyncedToAppleCalendar`フィールド追加 |
| `RunningRecord.swift` | `appleEventId`, `isSyncedToAppleCalendar`フィールド追加 |
| `SettingView.swift` | Appleカレンダー連携セクション追加、マスタートグルオフ時の解除処理追加 |
| `WorkoutSheetView.swift` | 保存時にApple Calendar同期を追加（Google同期と並行） |
| `RunningRecordFormView.swift` | ランニング保存時のApple Calendar同期追加 |
| `RunningViewModel.swift` | `saveRunningRecord()`の戻り値を`RunningRecord`に変更 |
| `WorkoutRow.swift` | 同期ステータスをGoogle/Apple両対応に更新 |
| `RunningRow.swift` | 同期ステータスをGoogle/Apple両対応に更新 |

## 設定画面の構成
```
外部連携セクション
├── カレンダー連携機能（マスタートグル）
├── Appleカレンダー（連携/解除/カレンダー選択）  ← 新規
├── Googleカレンダー（連携/解除/メール表示）     ← 既存
└── イベントの色（Google連携時のみ）             ← 既存
```

## 同期フロー
```
保存タップ → Google連携有効? → Google Calendar API (非同期)
           → Apple連携有効? → EventKit (同期的ローカル操作)
           → SwiftData保存
```

## Test plan
- [x] ビルド成功確認済み
- [x] swift-formatでフォーマット確認済み
- [ ] 設定 → Appleカレンダー「連携する」→ 権限ダイアログ表示確認
- [ ] 連携後、カレンダー選択Pickerが表示されることを確認
- [ ] トレーニング記録保存 → Apple Calendarにイベント作成確認
- [ ] ランニング記録保存 → Apple Calendarにイベント作成確認
- [ ] 連携解除 → 以降の保存でApple Calendarに同期されないことを確認
- [ ] Google/Apple両方有効時に両方に同期されることを確認
- [ ] マスタートグルオフ時にApple連携も解除されることを確認

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)