### PR TITLE
chore: .editorconfigを追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.swift]
+indent_style = space
+tab_width = 4
+indent_size = 4
+max_line_length = 100
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
## 要件・仕様
Xcode 16のEditorConfig対応を活用し、エディタ設定をプロジェクトレベルで統一する。

closes #152

## 処理概要
`.editorconfig`をプロジェクトルートに作成し、以下の設定を含めた：

**共通設定:**
- charset: utf-8
- end_of_line: lf
- insert_final_newline: true
- trim_trailing_whitespace: true

**Swift用:**
- indent_style: space
- tab_width/indent_size: 4
- max_line_length: 100（`.swift-format`と統一）

**Markdown用:**
- trim_trailing_whitespace: false（意図的な末尾スペースを保持）

**YAML用:**
- indent_size: 2

## 動作確認
- Xcodeでファイルを開いた際に自動でインデント設定が適用される
- 既存の`.swift-format`設定と矛盾しない

## 特記
なし

## 参考資料
- https://zenn.dev/miharun/articles/d2b47fea1c885a
- https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#Source-Editor