### PR TITLE
feat: String Catalog（ローカリゼーション対応）を導入

### DIFF
--- a/TrackFit/InfoPlist.xcstrings
+++ b/TrackFit/InfoPlist.xcstrings
@@ -1,0 +1,30 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TrackFit"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TrackFit"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/TrackFit/Localizable.xcstrings
+++ b/TrackFit/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
## 要件・仕様
String Catalog（Localizable.xcstrings）を導入し、アプリ内文言の一元管理および将来の多言語対応に備える。

closes #153

## 処理概要
以下の2つのString Catalogファイルを作成：

1. **`Localizable.xcstrings`** - 一般的なUI文言用
   - 日本語をソース言語として設定
   - 空の状態で作成（ビルド時にXcodeが自動収集）

2. **`InfoPlist.xcstrings`** - Info.plist用
   - `CFBundleDisplayName` と `CFBundleName` を設定

## 動作確認
- [ ] Xcodeでプロジェクトをビルドできること
- [ ] String Catalogファイルが正しく認識されること
- [ ] 将来の多言語対応時に翻訳追加が容易であること

## 特記
- 初期導入のため、既存のハードコードされた文言の移行は次フェーズで実施
- 対応言語の追加（英語等）は今後の計画に応じて実施

## 参考資料
- https://zenn.dev/miharun/articles/d2b47fea1c885a