### PR TITLE
test: ViewModel・Service層のテストカバレッジを拡充 (#146)

### DIFF
--- a/TrackFit/Services/GoogleCalendarAPI.swift
+++ b/TrackFit/Services/GoogleCalendarAPI.swift
@@ -169,7 +169,7 @@ struct GoogleCalendarAPI {
     }
 
     /// 共通のレスポンスバリデーション
-    private static func validateResponse(_ response: URLResponse, data: Data) throws {
+    static func validateResponse(_ response: URLResponse, data: Data) throws {
         if let httpResponse = response as? HTTPURLResponse,
             !(200..<300).contains(httpResponse.statusCode)
         {
@@ -179,7 +179,7 @@ struct GoogleCalendarAPI {
     }
 
     /// ワークアウトイベントのリクエストボディを生成
-    private static func buildWorkoutEventBody(workout: DailyWorkout, colorId: String)
+    static func buildWorkoutEventBody(workout: DailyWorkout, colorId: String)
         -> [String: Any]
     {
         let startString = DateHelper.iso8601String(from: workout.startDate)

--- a/TrackFitTests/CalendarAPIErrorTests.swift
+++ b/TrackFitTests/CalendarAPIErrorTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import TrackFit
+
+struct CalendarAPIErrorTests {
+
+    // MARK: - errorDescription
+
+    @Test func invalidURL_errorDescription() {
+        let error = CalendarAPIError.invalidURL
+        #expect(error.errorDescription == "無効なURLです")
+    }
+
+    @Test func httpError_errorDescription() {
+        let error = CalendarAPIError.httpError(statusCode: 404, body: "Not Found")
+        #expect(error.errorDescription == "APIエラー (404)\nNot Found")
+    }
+
+    @Test func httpError_serverError() {
+        let error = CalendarAPIError.httpError(statusCode: 500, body: "Internal Server Error")
+        #expect(error.errorDescription == "APIエラー (500)\nInternal Server Error")
+    }
+
+    @Test func tokenNotFound_errorDescription() {
+        let error = CalendarAPIError.tokenNotFound
+        #expect(error.errorDescription == "アクセストークンが見つかりません")
+    }
+
+    @Test func tokenExpired_errorDescription() {
+        let error = CalendarAPIError.tokenExpired
+        #expect(error.errorDescription == "アクセストークンの期限が切れています")
+    }
+
+    @Test func refreshFailed_errorDescription() {
+        let underlying = NSError(
+            domain: "test", code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "refresh error"
+            ])
+        let error = CalendarAPIError.refreshFailed(underlying: underlying)
+        #expect(error.errorDescription?.contains("トークン更新に失敗しました") == true)
+        #expect(error.errorDescription?.contains("refresh error") == true)
+    }
+
+    // MARK: - LocalizedError conformance
+
+    @Test func conformsToLocalizedError() {
+        let error: any LocalizedError = CalendarAPIError.invalidURL
+        #expect(error.errorDescription != nil)
+    }
+}

--- a/TrackFitTests/CalendarViewModelTests.swift
+++ b/TrackFitTests/CalendarViewModelTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import TrackFit
+
+@MainActor
+struct CalendarViewModelTests {
+
+    // MARK: - 初期状態
+
+    @Test func initialState_eventsIsEmpty() {
+        let vm = CalendarViewModel()
+        #expect(vm.events.isEmpty)
+    }
+
+    @Test func initialState_isLoadingIsFalse() {
+        let vm = CalendarViewModel()
+        #expect(vm.isLoading == false)
+    }
+
+    @Test func initialState_errorMessageIsNil() {
+        let vm = CalendarViewModel()
+        #expect(vm.errorMessage == nil)
+    }
+}

--- a/TrackFitTests/GoogleCalendarAPITests.swift
+++ b/TrackFitTests/GoogleCalendarAPITests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Testing
+
+@testable import TrackFit
+
+struct GoogleCalendarAPITests {
+
+    // MARK: - buildWorkoutEventBody
+
+    @Test func buildWorkoutEventBody_summary() {
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: [],
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "4")
+        #expect(body["summary"] as? String == "トレーニング")
+    }
+
+    @Test func buildWorkoutEventBody_colorId() {
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: [],
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "11")
+        #expect(body["colorId"] as? String == "11")
+    }
+
+    @Test func buildWorkoutEventBody_startDateTime() {
+        let startDate = Date()
+        let workout = DailyWorkout(
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(3600),
+            records: [],
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "4")
+        let start = body["start"] as? [String: String]
+        #expect(start?["dateTime"] == DateHelper.iso8601String(from: startDate))
+        #expect(start?["timeZone"] == "UTC")
+    }
+
+    @Test func buildWorkoutEventBody_endDateTime() {
+        let startDate = Date()
+        let endDate = startDate.addingTimeInterval(3600)
+        let workout = DailyWorkout(
+            startDate: startDate,
+            endDate: endDate,
+            records: [],
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "4")
+        let end = body["end"] as? [String: String]
+        #expect(end?["dateTime"] == DateHelper.iso8601String(from: endDate))
+        #expect(end?["timeZone"] == "UTC")
+    }
+
+    @Test func buildWorkoutEventBody_emptyRecords() {
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: [],
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "4")
+        #expect(body["description"] as? String == "")
+    }
+
+    @Test func buildWorkoutEventBody_singleRecord() {
+        let record = WorkoutRecord(exerciseName: "ベンチプレス", weight: 60.0, reps: 10, sets: 3)
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: [record],
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "4")
+        let description = body["description"] as? String ?? ""
+        #expect(description.contains("ベンチプレス"))
+        #expect(description.contains("60.0"))
+        #expect(description.contains("10"))
+        #expect(description.contains("3"))
+    }
+
+    @Test func buildWorkoutEventBody_multipleRecords() {
+        let records = [
+            WorkoutRecord(exerciseName: "ベンチプレス", weight: 60.0, reps: 10, sets: 3),
+            WorkoutRecord(exerciseName: "スクワット", weight: 80.0, reps: 8, sets: 4),
+        ]
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: records,
+            isSyncedToCalendar: false
+        )
+        let body = GoogleCalendarAPI.buildWorkoutEventBody(workout: workout, colorId: "4")
+        let description = body["description"] as? String ?? ""
+        #expect(description.contains("ベンチプレス"))
+        #expect(description.contains("スクワット"))
+    }
+
+    // MARK: - validateResponse
+
+    @Test func validateResponse_200_noThrow() throws {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let data = Data()
+        #expect(throws: Never.self) {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+        }
+    }
+
+    @Test func validateResponse_201_noThrow() throws {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 201, httpVersion: nil, headerFields: nil)!
+        let data = Data()
+        #expect(throws: Never.self) {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+        }
+    }
+
+    @Test func validateResponse_299_noThrow() throws {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 299, httpVersion: nil, headerFields: nil)!
+        let data = Data()
+        #expect(throws: Never.self) {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+        }
+    }
+
+    @Test func validateResponse_400_throws() {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 400, httpVersion: nil, headerFields: nil)!
+        let data = "Bad Request".data(using: .utf8)!
+        #expect(throws: CalendarAPIError.self) {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+        }
+    }
+
+    @Test func validateResponse_401_throws() {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 401, httpVersion: nil, headerFields: nil)!
+        let data = "Unauthorized".data(using: .utf8)!
+        #expect(throws: CalendarAPIError.self) {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+        }
+    }
+
+    @Test func validateResponse_500_throws() {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!
+        let data = "Server Error".data(using: .utf8)!
+        #expect(throws: CalendarAPIError.self) {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+        }
+    }
+
+    @Test func validateResponse_errorContainsStatusCodeAndBody() {
+        let url = URL(string: "https://example.com")!
+        let response = HTTPURLResponse(
+            url: url, statusCode: 403, httpVersion: nil, headerFields: nil)!
+        let body = "Forbidden"
+        let data = body.data(using: .utf8)!
+        do {
+            try GoogleCalendarAPI.validateResponse(response, data: data)
+            Issue.record("Expected error to be thrown")
+        } catch let error as CalendarAPIError {
+            if case .httpError(let statusCode, let errorBody) = error {
+                #expect(statusCode == 403)
+                #expect(errorBody == "Forbidden")
+            } else {
+                Issue.record("Expected httpError case")
+            }
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - EventsResponse decoding
+
+    @Test func eventsResponse_decodesCorrectly() throws {
+        let json = """
+            {
+                "items": [
+                    {
+                        "id": "event1",
+                        "summary": "トレーニング",
+                        "description": "テスト",
+                        "start": {"dateTime": "2025-01-01T10:00:00Z"},
+                        "end": {"dateTime": "2025-01-01T11:00:00Z"}
+                    }
+                ]
+            }
+            """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(GoogleCalendarAPI.EventsResponse.self, from: data)
+        #expect(decoded.items.count == 1)
+        #expect(decoded.items[0].id == "event1")
+        #expect(decoded.items[0].summary == "トレーニング")
+    }
+
+    @Test func eventsResponse_emptyItems() throws {
+        let json = """
+            {"items": []}
+            """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(GoogleCalendarAPI.EventsResponse.self, from: data)
+        #expect(decoded.items.isEmpty)
+    }
+
+    @Test func eventsResponse_multipleItems() throws {
+        let json = """
+            {
+                "items": [
+                    {"id": "e1", "summary": "A"},
+                    {"id": "e2", "summary": "B"},
+                    {"id": "e3", "summary": "C"}
+                ]
+            }
+            """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(GoogleCalendarAPI.EventsResponse.self, from: data)
+        #expect(decoded.items.count == 3)
+    }
+}

--- a/TrackFitTests/WorkoutViewModelTests.swift
+++ b/TrackFitTests/WorkoutViewModelTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import TrackFit
+
+@MainActor
+struct WorkoutViewModelTests {
+
+    // MARK: - 初期状態
+
+    @Test func initialState_exerciseName() {
+        let vm = WorkoutViewModel()
+        #expect(vm.exerciseName == "")
+    }
+
+    @Test func initialState_weight() {
+        let vm = WorkoutViewModel()
+        #expect(vm.weight == "")
+    }
+
+    @Test func initialState_sets() {
+        let vm = WorkoutViewModel()
+        #expect(vm.sets == 1)
+    }
+
+    @Test func initialState_reps() {
+        let vm = WorkoutViewModel()
+        #expect(vm.reps == 10)
+    }
+
+    @Test func initialState_eventId() {
+        let vm = WorkoutViewModel()
+        #expect(vm.eventId == nil)
+    }
+
+    @Test func initialState_errorMessage() {
+        let vm = WorkoutViewModel()
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test func initialState_isLoading() {
+        let vm = WorkoutViewModel()
+        #expect(vm.isLoading == false)
+    }
+
+    // MARK: - updateEvent
+
+    @Test func updateEvent_nilEventId_returnsFalse() async {
+        let vm = WorkoutViewModel()
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: [],
+            isSyncedToCalendar: false
+        )
+        // eventIdがnilのworkoutでupdateEventを呼ぶとfalseが返る
+        let result = await vm.updateEvent(dailyWorkout: workout)
+        #expect(result == false)
+    }
+
+    @Test func updateEvent_nilEventId_setsErrorMessage() async {
+        let vm = WorkoutViewModel()
+        let workout = DailyWorkout(
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(3600),
+            records: [],
+            isSyncedToCalendar: false
+        )
+        _ = await vm.updateEvent(dailyWorkout: workout)
+        #expect(vm.errorMessage == "イベントIDが取得できません。")
+    }
+}


### PR DESCRIPTION
## Summary
- `CalendarAPIError`の全エラーケースのerrorDescriptionテストを追加（7テスト）
- `WorkoutViewModel`の初期状態・updateEventガード句テストを追加（9テスト）
- `CalendarViewModel`の初期状態テストを追加（3テスト）
- `GoogleCalendarAPI`のbuildWorkoutEventBody・validateResponse・EventsResponseデコードテストを追加（17テスト）

## 変更箇所
| ファイル | 変更内容 |
|---|---|
| `CalendarAPIErrorTests.swift` | 新規: エラーメッセージの全ケーステスト |
| `WorkoutViewModelTests.swift` | 新規: 初期状態・eventId nil時のguard句テスト |
| `CalendarViewModelTests.swift` | 新規: 初期状態テスト |
| `GoogleCalendarAPITests.swift` | 新規: ヘルパーメソッド・レスポンスデコードテスト |
| `GoogleCalendarAPI.swift` | `buildWorkoutEventBody`と`validateResponse`をinternalに変更 |

## テスト追加数
- 既存: 39テスト
- 追加: 36テスト
- 合計: 75テスト

## Test plan
- [x] 全テストがパスすることを確認済み（TEST SUCCEEDED）
- [x] swift-formatでフォーマット確認済み
- [x] ビルド成功確認済み

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)