### PR TITLE
feat: ユーザー向けエラー通知UIを実装 (#147)

### DIFF
--- a/TrackFit/Utilities/Notification+Workout.swift
+++ b/TrackFit/Utilities/Notification+Workout.swift
@@ -4,6 +4,7 @@ import Foundation
 extension Notification.Name {
     static let didStartSyncingWorkout = Notification.Name("didStartSyncingWorkout")
     static let didFinishSyncingWorkout = Notification.Name("didFinishSyncingWorkout")
+    static let didFailSyncingWorkout = Notification.Name("didFailSyncingWorkout")
     static let shouldShowCalendarIntegrationAlert = Notification.Name(
         "shouldShowCalendarIntegrationAlert")
 }

--- a/TrackFit/ViewModels/RunningViewModel.swift
+++ b/TrackFit/ViewModels/RunningViewModel.swift
@@ -50,7 +50,7 @@ class RunningViewModel: ObservableObject {
     // MARK: - Methods
 
     /// ランニング記録を保存
-    func saveRunningRecord(context: ModelContext) {
+    func saveRunningRecord(context: ModelContext) throws {
         let record = RunningRecord(
             date: selectedDate,
             distance: distance,
@@ -59,6 +59,7 @@ class RunningViewModel: ObservableObject {
             memo: memo.isEmpty ? nil : memo
         )
         context.insert(record)
+        try context.save()
         resetForm()
     }
 

--- a/TrackFit/Views/WorkoutRecordView/CustomDatePicker.swift
+++ b/TrackFit/Views/WorkoutRecordView/CustomDatePicker.swift
@@ -9,6 +9,7 @@ struct CustomDatePicker: View {
     @Binding var savedDate: Date?
     var dailyWorkouts: [DailyWorkout]
     @State var selectedDate: Date = Date()
+    @State private var showSaveErrorAlert = false
 
     var body: some View {
         ZStack {
@@ -35,11 +36,19 @@ struct CustomDatePicker: View {
                     Button("保存") {
                         savedDate = selectedDate
                         guard let savedDate else { return }
-                        showDatePicker = false
                         let newDaily = DailyWorkout(
                             startDate: savedDate, endDate: savedDate.addingTimeInterval(60 * 60),
                             records: [], isSyncedToCalendar: false)
                         context.insert(newDaily)
+                        do {
+                            try context.save()
+                            showDatePicker = false
+                        } catch {
+                            #if DEBUG
+                                print("データ保存エラー: \(error.localizedDescription)")
+                            #endif
+                            showSaveErrorAlert = true
+                        }
                     }
                 }
                 .padding(.vertical, 15)
@@ -50,6 +59,11 @@ struct CustomDatePicker: View {
                 colorScheme == .dark ? Color.black.cornerRadius(30) : Color.white.cornerRadius(30)
             )
             .padding(.horizontal, 20)
+            .alert("データの保存に失敗しました", isPresented: $showSaveErrorAlert) {
+                Button("閉じる", role: .cancel) {}
+            } message: {
+                Text("もう一度お試しください。")
+            }
         }
     }
 }

--- a/TrackFit/Views/WorkoutRecordView/RunningRecordFormView.swift
+++ b/TrackFit/Views/WorkoutRecordView/RunningRecordFormView.swift
@@ -16,6 +16,7 @@ struct RunningRecordFormView: View {
 
     // 編集モード用
     var editingRecord: RunningRecord?
+    @State private var showSaveErrorAlert = false
 
     var body: some View {
         NavigationStack {
@@ -141,14 +142,39 @@ struct RunningRecordFormView: View {
                     viewModel.loadForEdit(record: record)
                 }
             }
+            .alert("データの保存に失敗しました", isPresented: $showSaveErrorAlert) {
+                Button("再試行") {
+                    saveRecord()
+                }
+                Button("閉じる", role: .cancel) {}
+            } message: {
+                Text("もう一度お試しください。")
+            }
         }
     }
 
     private func saveRecord() {
         if let existing = editingRecord {
             viewModel.updateRunningRecord(existing)
+            do {
+                try context.save()
+            } catch {
+                #if DEBUG
+                    print("データ保存エラー: \(error.localizedDescription)")
+                #endif
+                showSaveErrorAlert = true
+                return
+            }
         } else {
-            viewModel.saveRunningRecord(context: context)
+            do {
+                try viewModel.saveRunningRecord(context: context)
+            } catch {
+                #if DEBUG
+                    print("データ保存エラー: \(error.localizedDescription)")
+                #endif
+                showSaveErrorAlert = true
+                return
+            }
         }
         dismiss()
     }

--- a/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
@@ -26,6 +26,8 @@ struct WorkoutRecordView: View {
     @AppStorage("showIntegrationBanner") private var showIntegrationBanner: Bool = true
     // 同期失敗アラート用フラグ
     @State private var showSyncErrorAlert: Bool = false
+    @State private var syncErrorMessage: String = ""
+    @State private var syncErrorWorkoutID: UUID?
     // モーダル表示フラグ
     @State private var isShowCalendarIntegration: Bool = false
     // カレンダー連携促進アラート用フラグ
@@ -331,20 +333,26 @@ struct WorkoutRecordView: View {
             )
         }
         .alert(
-            "連携に失敗しました",
+            "カレンダー同期に失敗しました",
             isPresented: Binding(
                 get: { showSyncErrorAlert && isCalendarFeatureEnabled },
                 set: { showSyncErrorAlert = $0 }
             )
         ) {
+            Button("再試行") {
+                retrySync()
+            }
             Button("再連携") {
                 isShowCalendarIntegration = true
             }
-            Button("キャンセル", role: .cancel) {
-                showIntegrationBanner = true
+            Button("閉じる", role: .cancel) {
+                syncErrorMessage = ""
+                syncErrorWorkoutID = nil
             }
         } message: {
-            Text("もう一度サインインしてください。")
+            Text(
+                syncErrorMessage.isEmpty
+                    ? "もう一度サインインしてください。" : syncErrorMessage)
         }
         .alert(
             "Googleカレンダーと連携しませんか？",
@@ -397,6 +405,16 @@ struct WorkoutRecordView: View {
                 ) { notification in
                     if let id = notification.object as? UUID {
                         syncingWorkoutIDs.insert(id)
+                    }
+                }
+                .onReceive(
+                    NotificationCenter.default.publisher(for: .didFailSyncingWorkout)
+                ) { notification in
+                    if let id = notification.object as? UUID {
+                        syncErrorWorkoutID = id
+                        if let errorMsg = notification.userInfo?["errorMessage"] as? String {
+                            syncErrorMessage = errorMsg
+                        }
                     }
                 }
                 .onReceive(
@@ -560,6 +578,52 @@ struct WorkoutRecordView: View {
         for index in offsets {
             let record = filteredRunningRecords[index]
             context.delete(record)
+        }
+    }
+
+    private func retrySync() {
+        guard let targetID = syncErrorWorkoutID,
+            let daily = dailyWorkouts.first(where: { $0.id == targetID })
+        else { return }
+
+        syncErrorMessage = ""
+        syncErrorWorkoutID = nil
+
+        NotificationCenter.default.post(
+            name: .didStartSyncingWorkout, object: daily.id)
+
+        let viewModel = WorkoutViewModel()
+        Task { @MainActor in
+            var success: Bool
+            if daily.eventId == nil {
+                success = await viewModel.createEvent(dailyWorkout: daily)
+                if success, let newEventId = viewModel.eventId {
+                    daily.eventId = newEventId
+                }
+            } else {
+                success = await viewModel.updateEvent(dailyWorkout: daily)
+            }
+
+            if success {
+                daily.isSyncedToCalendar = true
+                do {
+                    try context.save()
+                } catch {
+                    daily.isSyncedToCalendar = false
+                }
+            } else {
+                daily.isSyncedToCalendar = false
+                let errorMsg =
+                    viewModel.errorMessage ?? "カレンダーとの同期中にエラーが発生しました。"
+                NotificationCenter.default.post(
+                    name: .didFailSyncingWorkout,
+                    object: daily.id,
+                    userInfo: ["errorMessage": errorMsg]
+                )
+            }
+
+            NotificationCenter.default.post(
+                name: .didFinishSyncingWorkout, object: daily.id)
         }
     }
 }

--- a/TrackFit/Views/WorkoutRecordView/WorkoutSheetView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutSheetView.swift
@@ -21,6 +21,7 @@ struct WorkoutSheetView: View {
     @State private var isStartSheetPresented = false
     @State private var isEndSheetPresented = false
     @State private var isAddingNewRecord = false
+    @State private var showSaveErrorAlert = false
 
     @Environment(\.modelContext) private var context
     @AppStorage("isCalendarLinked") private var isCalendarLinked: Bool = false
@@ -75,6 +76,14 @@ struct WorkoutSheetView: View {
             editSheet(for: rec)
         }
         .overlay(addRecordButton)
+        .alert("データの保存に失敗しました", isPresented: $showSaveErrorAlert) {
+            Button("再試行") {
+                saveWithoutCalendar()
+            }
+            Button("閉じる", role: .cancel) {}
+        } message: {
+            Text("もう一度お試しください。")
+        }
     }
 
     // MARK: - 日時ボタン
@@ -226,11 +235,13 @@ struct WorkoutSheetView: View {
                     #endif
                 }
 
-                if let errorMsg = viewModel.errorMessage {
-                    #if DEBUG
-                        print("Google Calendar同期エラー: \(errorMsg)")
-                    #endif
-                }
+                let errorMsg =
+                    viewModel.errorMessage ?? "カレンダーとの同期中にエラーが発生しました。"
+                NotificationCenter.default.post(
+                    name: .didFailSyncingWorkout,
+                    object: daily.id,
+                    userInfo: ["errorMessage": errorMsg]
+                )
             }
             NotificationCenter.default.post(
                 name: .didFinishSyncingWorkout, object: daily.id)
@@ -245,6 +256,8 @@ struct WorkoutSheetView: View {
             #if DEBUG
                 print("データ保存エラー: \(error.localizedDescription)")
             #endif
+            showSaveErrorAlert = true
+            return
         }
         dismiss()
 


### PR DESCRIPTION
## Summary
- カレンダー同期エラー時に実際のエラー内容をユーザーに表示し、再試行ボタンを提供
- データ保存（`context.save()`）失敗時にリトライ付きアラートを表示
- `didFailSyncingWorkout` 通知を新規追加し、エラーメッセージを `userInfo` で伝達

## 変更ファイル
- `Notification+Workout.swift`: `didFailSyncingWorkout` 通知名追加
- `RunningViewModel.swift`: `saveRunningRecord` を `throws` に変更
- `WorkoutSheetView.swift`: 同期失敗通知送信・保存エラーアラート追加
- `RunningRecordFormView.swift`: 保存エラーハンドリング・アラート追加
- `CustomDatePicker.swift`: `context.save()` 追加・保存エラーアラート追加
- `WorkoutRecordView.swift`: エラー詳細表示・再試行・再連携ボタン追加

## Test plan
- [ ] カレンダー同期失敗時にエラー詳細メッセージがアラートに表示されること
- [ ] 「再試行」ボタンで再同期が実行されること
- [ ] データ保存失敗時にアラートが表示され、再試行で再度保存が試みられること
- [ ] 正常系（同期成功・保存成功）の動作に影響がないこと
- [ ] `xcodebuild build` でコンパイルエラーがないこと ✅

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)