### PR TITLE
refactor: データ取得のパフォーマンス最適化

### DIFF
--- a/TrackFit/ViewModels/HomeViewModel.swift
+++ b/TrackFit/ViewModels/HomeViewModel.swift
@@ -33,7 +33,7 @@ class HomeViewModel: ObservableObject {
     ///   - workouts: 集計対象のトレーニング記録
     ///   - runningRecords: 集計対象のランニング記録
     func updateStats(workouts: [DailyWorkout], runningRecords: [RunningRecord] = []) {
-        self.recentWorkouts = Array(workouts.sorted(by: { $0.startDate > $1.startDate }).prefix(5))
+        self.recentWorkouts = Array(workouts.prefix(5))
         self.currentWeekStreak = calculateStreak(workouts: workouts, runningRecords: runningRecords)
 
         self.activityLog = calculateActivityLog(workouts: workouts, runningRecords: runningRecords)

--- a/TrackFit/Views/TrainingHistoryView/ExerciseDetailView.swift
+++ b/TrackFit/Views/TrainingHistoryView/ExerciseDetailView.swift
@@ -23,13 +23,12 @@ struct ExerciseDetailView: View {
 
     // グラフ用: 日付昇順にならべかえ（重量がnilでないもののみ）
     private var chartData: [(date: Date, maxWeight: Double)] {
-        let history = exerciseHistory.reversed()  // 昇順にする
-        return history.compactMap { item in
+        exerciseHistory.compactMap { item in
             if let weight = item.record.weight {
                 return (item.date, weight)
             }
             return nil
-        }
+        }.reversed()
     }
 
     var body: some View {

--- a/TrackFit/Views/TrainingHistoryView/TrainingHistoryView.swift
+++ b/TrackFit/Views/TrainingHistoryView/TrainingHistoryView.swift
@@ -14,6 +14,13 @@ struct TrainingHistoryView: View {
     @State private var selectedRunType: RunType?
     @Binding var isSearchPresented: Bool
 
+    private static let monthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy年M月"
+        formatter.locale = Locale(identifier: "ja_JP")
+        return formatter
+    }()
+
     init(isSearchPresented: Binding<Bool> = .constant(false)) {
         self._isSearchPresented = isSearchPresented
     }
@@ -45,12 +52,8 @@ struct TrainingHistoryView: View {
 
     // 月ごとにグループ化されたランニング記録
     private var groupedRunningRecords: [(month: String, records: [RunningRecord])] {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy年M月"
-        formatter.locale = Locale(identifier: "ja_JP")
-
         let grouped = Dictionary(grouping: filteredRunningRecords) { record in
-            formatter.string(from: record.date)
+            Self.monthFormatter.string(from: record.date)
         }
         return grouped.map { (month: $0.key, records: $0.value) }
             .sorted { $0.records[0].date > $1.records[0].date }

--- a/TrackFit/Views/WorkoutCalendarHistory/CalendarHistoryGridView.swift
+++ b/TrackFit/Views/WorkoutCalendarHistory/CalendarHistoryGridView.swift
@@ -9,17 +9,25 @@ struct CalendarHistoryGridView: View {
 
     private let calendar = Calendar.current
 
+    private var workoutsByDay: [Date: [DailyWorkout]] {
+        Dictionary(grouping: dailyWorkouts) { workout in
+            calendar.startOfDay(for: workout.startDate)
+        }
+    }
+
     var body: some View {
+        let groupedWorkouts = workoutsByDay
         LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 7), spacing: 1) {
             ForEach(monthDates, id: \.self) { date in
+                let dayWorkouts = groupedWorkouts[calendar.startOfDay(for: date)]
                 CalendarHistoryDateCell(
                     date: date,
                     isSelected: selectedDate != nil
                         && calendar.isDate(date, inSameDayAs: selectedDate!),
                     isCurrentMonth: calendar.isDate(
                         date, equalTo: currentMonth, toGranularity: .month),
-                    hasWorkout: hasWorkout(on: date),
-                    workoutCount: workouts(for: date).count,
+                    hasWorkout: dayWorkouts != nil,
+                    workoutCount: dayWorkouts?.count ?? 0,
                     isToday: calendar.isDateInToday(date)
                 ) {
                     handleDateTap(date: date)
@@ -51,21 +59,8 @@ struct CalendarHistoryGridView: View {
         return dates
     }
 
-    private func hasWorkout(on date: Date) -> Bool {
-        dailyWorkouts.contains { workout in
-            calendar.isDate(workout.startDate, inSameDayAs: date)
-        }
-    }
-
-    private func workouts(for date: Date) -> [DailyWorkout] {
-        return dailyWorkouts.filter { workout in
-            calendar.isDate(workout.startDate, inSameDayAs: date)
-        }
-    }
-
     private func handleDateTap(date: Date) {
         selectedDate = date
-        let workoutsForDate = workouts(for: date)
-        selectedWorkout = workoutsForDate.first
+        selectedWorkout = workoutsByDay[calendar.startOfDay(for: date)]?.first
     }
 }

--- a/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
@@ -96,7 +96,7 @@ struct WorkoutRecordView: View {
             }
         }
 
-        return filtered.sorted { $0.startDate < $1.startDate }
+        return filtered
     }
 
     private var filteredRunningRecords: [RunningRecord] {
@@ -137,7 +137,7 @@ struct WorkoutRecordView: View {
             }
         }
 
-        return filtered.sorted { $0.date < $1.date }
+        return filtered
     }
 
     private var dateRangeLabel: String {


### PR DESCRIPTION
## Summary
- `WorkoutRecordView`: `@Query`でソート済みのデータに対する冗長な`.sorted()`を削除
- `CalendarHistoryGridView`: `workoutsByDay` Dictionaryで事前グループ化し、O(42×n×2) → O(n+42)に改善
- `TrainingHistoryView`: `DateFormatter`を`private static let`に抽出し毎回生成を排除
- `HomeViewModel`: `@Query`で降順ソート済みのデータに対する冗長な`.sorted()`を削除
- `ExerciseDetailView`: `chartData`の`.reversed()`+`.compactMap()`を`.compactMap()`+`.reversed()`に変更

## 変更詳細

| ファイル | 最適化内容 | 効果 |
|---|---|---|
| `WorkoutRecordView.swift` | `filteredWorkouts`/`filteredRunningRecords`の冗長`.sorted()`削除 | `@Query`のソート順を活用し不要な再ソートを排除 |
| `CalendarHistoryGridView.swift` | `workoutsByDay` Dictionaryで事前グループ化 | O(42×n×2) → O(n+42) |
| `TrainingHistoryView.swift` | `DateFormatter`を`private static let`に抽出 | View再描画ごとの生成コストを排除 |
| `HomeViewModel.swift` | `updateStats`の`.sorted(by:)`削除 | 呼び出し元の`@Query`で降順ソート済み |
| `ExerciseDetailView.swift` | `.compactMap()`+`.reversed()`に変更 | nil要素を先に除外してから反転 |

## Test plan
- [x] `xcodebuild build` でコンパイルエラーがないことを確認
- [x] 筋トレ記録一覧の表示順序が変わらないことを確認
- [x] ランニング記録一覧の表示順序が変わらないことを確認
- [x] カレンダーグリッドのワークアウト表示が正しいことを確認
- [x] ホーム画面の直近5件表示が正しいことを確認
- [x] 種目詳細のグラフ表示が正しいことを確認

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)