### PR TITLE
fix: スワイプ削除に確認ダイアログを追加

### DIFF
--- a/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
+++ b/TrackFit/Views/WorkoutRecordView/WorkoutRecordView.swift
@@ -5,6 +5,9 @@ import SwiftUI
 // MARK: - メインビュー
 struct WorkoutRecordView: View {
     @State private var syncingWorkoutIDs: Set<UUID> = []
+    // 削除確認用
+    @State private var workoutToDelete: DailyWorkout?
+    @State private var runningRecordToDelete: RunningRecord?
 
     enum WorkoutType: String, CaseIterable {
         case weightTraining = "筋トレ"
@@ -373,6 +376,52 @@ struct WorkoutRecordView: View {
         .sheet(item: $editingRunningRecord) { record in
             RunningRecordFormView(editingRecord: record)
         }
+        .alert(
+            "トレーニングを削除",
+            isPresented: Binding(
+                get: { workoutToDelete != nil },
+                set: { if !$0 { workoutToDelete = nil } }
+            )
+        ) {
+            Button("削除", role: .destructive) {
+                if let workout = workoutToDelete {
+                    context.delete(workout)
+                    workoutToDelete = nil
+                }
+            }
+            Button("キャンセル", role: .cancel) {
+                workoutToDelete = nil
+            }
+        } message: {
+            if let workout = workoutToDelete {
+                Text(
+                    "\(DateHelper.formattedDate(workout.startDate))のトレーニングを削除しますか？\nこの操作は元に戻せません。"
+                )
+            }
+        }
+        .alert(
+            "ランニング記録を削除",
+            isPresented: Binding(
+                get: { runningRecordToDelete != nil },
+                set: { if !$0 { runningRecordToDelete = nil } }
+            )
+        ) {
+            Button("削除", role: .destructive) {
+                if let record = runningRecordToDelete {
+                    context.delete(record)
+                    runningRecordToDelete = nil
+                }
+            }
+            Button("キャンセル", role: .cancel) {
+                runningRecordToDelete = nil
+            }
+        } message: {
+            if let record = runningRecordToDelete {
+                Text(
+                    "\(DateHelper.formattedDate(record.date))のランニング記録を削除しますか？\nこの操作は元に戻せません。"
+                )
+            }
+        }
     }
 
     // MARK: - Private Views
@@ -550,16 +599,14 @@ struct WorkoutRecordView: View {
     }
 
     private func deleteDailyWorkout(at offsets: IndexSet) {
-        for index in offsets {
-            let dailyWorkout = filteredWorkouts[index]
-            context.delete(dailyWorkout)
+        if let index = offsets.first {
+            workoutToDelete = filteredWorkouts[index]
         }
     }
 
     private func deleteRunningRecord(at offsets: IndexSet) {
-        for index in offsets {
-            let record = filteredRunningRecords[index]
-            context.delete(record)
+        if let index = offsets.first {
+            runningRecordToDelete = filteredRunningRecords[index]
         }
     }
 }


### PR DESCRIPTION
## Summary
- 筋トレ記録・ランニング記録のスワイプ削除時に確認Alertを表示するように変更
- 既存の `EditWorkoutSheetView` / `ExerciseManagementView` と同じ `.alert()` パターンを採用
- 誤操作による即座のデータ削除を防止

## 変更内容
- `@State private var workoutToDelete` / `runningRecordToDelete` を追加
- `deleteDailyWorkout` / `deleteRunningRecord` を即座削除から対象保存に変更
- 削除確認Alert（日付表示付き）を2つ追加

## Test plan
- [ ] 筋トレ記録をスワイプ削除 → 確認ダイアログが表示される
- [ ] 「キャンセル」押下 → 削除されない
- [ ] 「削除」押下 → データが削除される
- [ ] ランニング記録でも同様の動作を確認
- [ ] 確認ダイアログに正しい日付が表示される

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)